### PR TITLE
feat: dont auto-set irrelevant field mappings when setting up a data source

### DIFF
--- a/nextjs/src/app/(app)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(app)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -138,11 +138,16 @@ export default function Page({
    * badKeys = ["email"].
    */
   function useGuessedField(
-    field: string,
+    field: keyof FormInputs,
     guessKeys: string[],
     badKeys: string[] = []
   ) {
     useEffect(() => {
+      // @ts-ignore
+      if (!collectFields.includes(field)) {
+        form.setValue(field, null)
+        return
+      }
       const guess = testSourceResult.data?.testDataSource.fieldDefinitions?.find(
         (field: ({ label?: string | null, value: string })) => {
           const isMatch = (fieldName: string|null|undefined, guessKey: string) => {
@@ -176,7 +181,7 @@ export default function Page({
         // @ts-ignore
         form.setValue(field, guess?.value)
       }
-    }, [testSourceResult.data?.testDataSource.fieldDefinitions, form, setGuessed])
+    }, [testSourceResult.data?.testDataSource.fieldDefinitions, form, collectFields, setGuessed])
   }
 
   useGuessedField('geographyColumn', ["postcode", "postal code", "zip code", "zip"])


### PR DESCRIPTION
Somehow a field was misconfigured when onboarding an Action Network user.

This could have been because of the auto-configuration of field mappings.

This PR makes that process clear any mapping on irrelevant fields (e.g. start time => null for member lists).