### PR TITLE
When there are no sites, the tile json API should still work

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -1946,6 +1946,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         external_data_source: Union["ExternalDataSource", str],
     ) -> DataPermissions:
         if external_data_source is None:
+            logger.debug("No source provided, returning default permissions")
             return cls.DataPermissions(
                 can_display_points=False,
                 can_display_details=False,

--- a/hub/views/vector_tiles.py
+++ b/hub/views/vector_tiles.py
@@ -66,9 +66,8 @@ class ExternalDataSourceTileView(MVTView, DetailView):
             return super().get(request, *args, **kwargs)
         except Exception as e:
             logger.warning(f"Could not view location data: {e}")
-            return HttpResponseForbidden(
-                "You don't have permission to view location data for this data source."
-            )
+            logger.exception(e)
+            return HttpResponseForbidden(e)
 
     def get_id(self):
         return self.kwargs.get(self.pk_url_kwarg)
@@ -92,16 +91,16 @@ class ExternalDataSourceTileView(MVTView, DetailView):
         """
         Obey hub-level layer filtering logic.
         """
-        logger.debug("getting filter", hostname, external_data_source_id)
         site = Site.objects.filter(hostname=hostname).first()
         if site is not None:
-            hub: HubHomepage = site.root_page.specific
-            layers = hub.get_layers()
-            logger.debug("filter in layers", layers)
-            if isinstance(layers, list):
-                for layer in layers:
-                    if layer.get("source") == external_data_source_id:
-                        return layer.get("filter", {})
+            hub = site.root_page.specific
+            if isinstance(hub, HubHomepage):
+                layers = hub.get_layers()
+                logger.debug("filter in layers", layers)
+                if isinstance(layers, list):
+                    for layer in layers:
+                        if layer.get("source") == external_data_source_id:
+                            return layer.get("filter", {})
         return {}
 
 


### PR DESCRIPTION
When the repo has just been installed, Wagtail adds a default Site and root page. This PR prevents the tilserver from erroring out in that situation.