### PR TITLE
fix: prevent middleware blocking sentry requests

### DIFF
--- a/hub/tests/test_sources.py
+++ b/hub/tests/test_sources.py
@@ -233,7 +233,11 @@ class TestExternalDataSource:
             [self.source.get_record_id(record) for record in records]
         )
         # Check
-        assert len(records) == 2
+        try:
+            assert len(records) == 2
+        except Exception:
+            print(f"Incorrect record count: expected 2, found {len(records)}")
+            assert False
         # Check the email field instead of postcode, because Mailchimp doesn't set
         # the postcode without a full address, which is not present in this test
         for test_record in test_record_data:

--- a/nextjs/src/middleware.ts
+++ b/nextjs/src/middleware.ts
@@ -24,6 +24,12 @@ export const middleware: NextMiddleware = (req) => {
     },
   });
 
+  // Don't process Sentry requests
+  // (see next.config.js Sentry tunnelRoute)
+  if (req.nextUrl.pathname === "/monitoring") {
+    return response
+  }
+
   const url = req.nextUrl;
 
   // Get hostname of request (e.g. demo.vercel.pub, demo.localhost:3000)


### PR DESCRIPTION
Fix front-end sentry logging. The internal sentry requests were being blocked by our middleware.