### PR TITLE
Feature/map 305 improve action network performance

### DIFF
--- a/hub/management/commands/trigger_data_source_jobs.py
+++ b/hub/management/commands/trigger_data_source_jobs.py
@@ -1,0 +1,33 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from asgiref.sync import async_to_sync
+
+from hub.models import ExternalDataSource
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Trigger import and update jobs for an external data source"
+
+    def add_arguments(self, parser):
+        parser.add_argument("id", type=str)
+        parser.add_argument("-o", "--only", type=str)
+
+    def handle(self, *args, **options):
+        async_to_sync(self.async_handle)(*args, **options)
+
+    async def async_handle(self, *args, **options):
+        source: ExternalDataSource = await ExternalDataSource.objects.aget(
+            id=options["id"]
+        )
+        only = options.get("only")
+        if not only:
+            await source.schedule_import_all()
+            await source.schedule_refresh_all()
+        elif only == "import":
+            await source.schedule_import_all()
+        else:
+            await source.schedule_refresh_all()

--- a/hub/models.py
+++ b/hub/models.py
@@ -2809,9 +2809,7 @@ class ActionNetworkSource(ExternalDataSource):
         return fields
 
     async def fetch_all(self):
-        # TODO: pagination
-        list = self.client.get_people()
-        return list.to_dicts()
+        return self.client.get_people()
 
     async def fetch_many(self, member_ids: list[str]):
         member_ids = [self.uuid_to_prefixed_id(id) for id in list(set(member_ids))]
@@ -2821,7 +2819,7 @@ class ActionNetworkSource(ExternalDataSource):
             osdi_filter_str = " or ".join(
                 [f"identifier eq '{member_id}'" for member_id in batch]
             )
-            members += self.client.get_people(filter=osdi_filter_str).to_dicts()
+            members += list(self.client.get_people(filter=osdi_filter_str))
         return members
 
     async def fetch_one(self, member_id: str):

--- a/hub/models.py
+++ b/hub/models.py
@@ -63,7 +63,7 @@ from hub.views.mapped import ExternalDataSourceAutoUpdateWebhook
 from utils.log import get_simple_debug_logger
 from utils.nominatim import address_to_geojson
 from utils.postcodesIO import PostcodesIOResult, get_bulk_postcode_geo
-from utils.py import batched, ensure_list, get
+from utils.py import batched, ensure_list, get, is_maybe_id
 
 User = get_user_model()
 
@@ -1131,7 +1131,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         statuses = dict()
 
         for job in jobs:
-            job_count = len(job.args.get("member_ids", []))
+            job_count = len(job.args.get("members", []))
             total += job_count
             if statuses.get(job.status, None) is not None:
                 statuses[job.status] += job_count
@@ -1282,11 +1282,19 @@ class ExternalDataSource(PolymorphicModel, Analytics):
             "Get member ID not implemented for this data source type."
         )
 
-    async def import_many(self, member_ids: list[str]):
+    async def import_many(self, members: list):
         """
         Copy data to this database for use in dashboarding features.
         """
-        data = await self.fetch_many(member_ids)
+
+        if not members:
+            logger.error("import_many called with 0 members")
+            return
+
+        if is_maybe_id(members[0]):
+            data = await self.fetch_many(members)
+        else:
+            data = members
 
         # A Local Intelligence Hub record of this data
         data_set, created = await DataSet.objects.aupdate_or_create(
@@ -1677,7 +1685,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
 
     async def map_many(
         self,
-        members: list[Union[str, any]],
+        members: list,
         loaders: Loaders,
         mapping: list[UpdateMapping] = None,
     ) -> list[MappedMember]:
@@ -1693,7 +1701,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
 
     async def refresh_one(
         self,
-        member_id: Union[str, any],
+        member,
         update_kwargs={},
         mapping: list[UpdateMapping] = None,
     ):
@@ -1706,12 +1714,12 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         if len(mapping) == 0:
             return
         loaders = await self.get_loaders()
-        mapped_record = await self.map_one(member_id, loaders, mapping=mapping)
+        mapped_record = await self.map_one(member, loaders, mapping=mapping)
         return await self.update_one(mapped_record, **update_kwargs)
 
     async def refresh_many(
         self,
-        member_ids: list[Union[str, any]],
+        members: list,
         update_kwargs={},
         mapping: list[UpdateMapping] = None,
     ):
@@ -1724,7 +1732,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         if len(mapping) == 0:
             return
         loaders = await self.get_loaders()
-        mapped_records = await self.map_many(member_ids, loaders, mapping=mapping)
+        mapped_records = await self.map_many(members, loaders, mapping=mapping)
         return await self.update_many(mapped_records=mapped_records, **update_kwargs)
 
     # UI
@@ -1765,15 +1773,15 @@ class ExternalDataSource(PolymorphicModel, Analytics):
 
         member_ids = self.get_member_ids_from_webhook(body)
         if len(member_ids) == 1:
-            async_to_sync(self.schedule_refresh_one)(member_id=member_ids[0])
+            async_to_sync(self.schedule_refresh_one)(member=member_ids[0])
         else:
-            async_to_sync(self.schedule_refresh_many)(member_ids=member_ids)
+            async_to_sync(self.schedule_refresh_many)(members=member_ids)
         return HttpResponse(status=200)
 
     # Scheduling
 
     @classmethod
-    async def deferred_refresh_one(cls, external_data_source_id: str, member_id: str):
+    async def deferred_refresh_one(cls, external_data_source_id: str, member: str):
         if not cls.allow_updates:
             logger.error(f"Updates requested for non-updatable CRM {cls}")
             return
@@ -1781,11 +1789,11 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         external_data_source: ExternalDataSource = await cls.objects.aget(
             id=external_data_source_id
         )
-        await external_data_source.refresh_one(member_id=member_id)
+        await external_data_source.refresh_one(member=member)
 
     @classmethod
     async def deferred_refresh_many(
-        cls, external_data_source_id: str, member_ids: list[str], request_id: str = None
+        cls, external_data_source_id: str, members: list, request_id: str = None
     ):
         if not cls.allow_updates:
             logger.error(f"Updates requested for non-updatable CRM {cls}")
@@ -1794,7 +1802,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         external_data_source: ExternalDataSource = await cls.objects.aget(
             id=external_data_source_id
         )
-        await external_data_source.refresh_many(member_ids=member_ids)
+        await external_data_source.refresh_many(members=members)
 
     @classmethod
     async def deferred_refresh_all(
@@ -1811,10 +1819,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         members = await external_data_source.fetch_all()
         batches = batched(members, settings.IMPORT_UPDATE_ALL_BATCH_SIZE)
         for batch in batches:
-            member_ids = [
-                external_data_source.get_record_id(member) for member in batch
-            ]
-            await external_data_source.schedule_refresh_many(member_ids, request_id)
+            await external_data_source.schedule_refresh_many(batch, request_id)
 
     @classmethod
     async def deferred_refresh_webhooks(cls, external_data_source_id: str):
@@ -1833,12 +1838,12 @@ class ExternalDataSource(PolymorphicModel, Analytics):
 
     @classmethod
     async def deferred_import_many(
-        cls, external_data_source_id: str, member_ids: list[str], request_id: str = None
+        cls, external_data_source_id: str, members: list, request_id: str = None
     ):
         external_data_source: ExternalDataSource = await cls.objects.aget(
             id=external_data_source_id
         )
-        await external_data_source.import_many(member_ids=member_ids)
+        await external_data_source.import_many(members=members)
 
     @classmethod
     async def deferred_import_all(
@@ -1851,17 +1856,19 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         members = await external_data_source.fetch_all()
         batches = batched(members, settings.IMPORT_UPDATE_ALL_BATCH_SIZE)
         for batch in batches:
-            member_ids = [
-                external_data_source.get_record_id(member) for member in batch
-            ]
             await external_data_source.schedule_import_many(
-                member_ids, request_id=request_id
+                members, request_id=request_id
             )
 
-    async def schedule_refresh_one(self, member_id: str) -> int:
+    async def schedule_refresh_one(self, member) -> int:
         if not self.allow_updates:
             logger.error(f"Updates requested for non-updatable CRM {self}")
             return
+
+        if is_maybe_id(member):
+            member_id = member
+        else:
+            member_id = self.get_record_id(member)
 
         try:
             return await refresh_one.configure(
@@ -1869,16 +1876,25 @@ class ExternalDataSource(PolymorphicModel, Analytics):
                 # https://procrastinate.readthedocs.io/en/stable/howto/queueing_locks.html
                 queueing_lock=f"update_one_{str(self.id)}_{str(member_id)}",
                 schedule_in={"seconds": settings.SCHEDULED_UPDATE_SECONDS_DELAY},
-            ).defer_async(external_data_source_id=str(self.id), member_id=member_id)
+            ).defer_async(external_data_source_id=str(self.id), member=member)
         except (UniqueViolation, IntegrityError):
             pass
 
     async def schedule_refresh_many(
-        self, member_ids: list[str], request_id: str = None
+        self, members: list[str] | list[dict], request_id: str = None
     ) -> int:
         if not self.allow_updates:
             logger.error(f"Updates requested for non-updatable CRM {self}")
             return
+
+        if not members:
+            logger.error("Updates requested for 0 members")
+            return
+
+        if is_maybe_id(members[0]):
+            member_ids = members
+        else:
+            member_ids = [self.get_record_id(member) for member in members]
 
         member_ids_hash = hashlib.md5("".join(sorted(member_ids)).encode()).hexdigest()
         try:
@@ -1890,7 +1906,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
             ).defer_async(
                 request_id=request_id,
                 external_data_source_id=str(self.id),
-                member_ids=member_ids,
+                members=members,
             )
         except (UniqueViolation, IntegrityError):
             pass
@@ -1910,9 +1926,16 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         except (UniqueViolation, IntegrityError):
             pass
 
-    async def schedule_import_many(
-        self, member_ids: list[str], request_id: str = None
-    ) -> int:
+    async def schedule_import_many(self, members: list, request_id: str = None) -> int:
+        if not members:
+            logger.error("Import requested for 0 members")
+            return
+
+        if is_maybe_id(members[0]):
+            member_ids = members
+        else:
+            member_ids = [self.get_record_id(member) for member in members]
+
         member_ids_hash = hashlib.md5("".join(sorted(member_ids)).encode()).hexdigest()
         try:
             return await import_many.configure(
@@ -1922,7 +1945,7 @@ class ExternalDataSource(PolymorphicModel, Analytics):
                 schedule_in={"seconds": settings.SCHEDULED_UPDATE_SECONDS_DELAY},
             ).defer_async(
                 external_data_source_id=str(self.id),
-                member_ids=member_ids,
+                members=members,
                 request_id=request_id,
             )
         except (UniqueViolation, IntegrityError):
@@ -2262,10 +2285,10 @@ class AirtableSource(ExternalDataSource):
         payloads = webhook.payloads(cursor=webhook_object.cursor)
         for payload in payloads:
             webhook_object.cursor = webhook_object.cursor + 1
-            for table_id, deets in payload.changed_tables_by_id.items():
+            for table_id, details in payload.changed_tables_by_id.items():
                 if table_id == self.table_id:
-                    member_ids += deets.changed_records_by_id.keys()
-                    member_ids += deets.created_records_by_id.keys()
+                    member_ids += details.changed_records_by_id.keys()
+                    member_ids += details.created_records_by_id.keys()
         webhook_object.save()
         member_ids = list(sorted(set(member_ids)))
         logger.debug("Webhook member result", webhook_object.cursor, member_ids)
@@ -2809,6 +2832,7 @@ class ActionNetworkSource(ExternalDataSource):
         return fields
 
     async def fetch_all(self):
+        # returns an iterator that *should* work for big lists
         return self.client.get_people()
 
     async def fetch_many(self, member_ids: list[str]):

--- a/hub/parsons/action_network/action_network.py
+++ b/hub/parsons/action_network/action_network.py
@@ -144,6 +144,26 @@ class ActionNetwork(object):
                 if count >= limit:
                     return Table(return_list[0:limit])
 
+    def _get_generator(self, object_name, limit=None, per_page=25, filter=None):
+        # returns a generator of entries for a given object, such as people, tags, or actions
+        # Filter can only be applied to people, petitions, events, forms, fundraising_pages,
+        # event_campaigns, campaigns, advocacy_campaigns, signatures, attendances, submissions,
+        # donations and outreaches.
+        # See Action Network API docs for more info: https://actionnetwork.org/docs/v2/
+        count = 0
+        page = 1
+        while True:
+            response = self._get_page(object_name, page, per_page, filter=filter)
+            page = page + 1
+            response_list = response["_embedded"][list(response["_embedded"])[0]]
+            if not response_list:
+                return
+            for item in response_list:
+                yield item
+                count = count + 1
+                if limit and count >= limit:
+                    return
+
     # Advocacy Campaigns
     def get_advocacy_campaigns(self, limit=None, per_page=25, page=None, filter=None):
         """
@@ -1213,7 +1233,7 @@ class ActionNetwork(object):
         """
         if page:
             return self._get_page("people", page, per_page, filter=filter)
-        return self._get_entry_list("people", limit, per_page, filter=filter)
+        return self._get_generator("people", limit, per_page, filter=filter)
 
     def get_person(self, person_id):
         """

--- a/hub/tasks.py
+++ b/hub/tasks.py
@@ -7,23 +7,23 @@ from procrastinate.contrib.django import app
 
 
 @app.task(queue="external_data_sources")
-async def refresh_one(external_data_source_id: str, member_id: str):
+async def refresh_one(external_data_source_id: str, member):
     from hub.models import ExternalDataSource
 
     await ExternalDataSource.deferred_refresh_one(
-        external_data_source_id=external_data_source_id, member_id=member_id
+        external_data_source_id=external_data_source_id, member=member
     )
 
 
 @app.task(queue="external_data_sources", retry=settings.IMPORT_UPDATE_MANY_RETRY_COUNT)
 async def refresh_many(
-    external_data_source_id: str, member_ids: list[str], request_id: str = None
+    external_data_source_id: str, members: list, request_id: str = None
 ):
     from hub.models import ExternalDataSource
 
     await ExternalDataSource.deferred_refresh_many(
         external_data_source_id=external_data_source_id,
-        member_ids=member_ids,
+        members=members,
         request_id=request_id,
     )
 
@@ -50,13 +50,13 @@ async def refresh_webhooks(external_data_source_id: str, timestamp=None):
 
 @app.task(queue="external_data_sources", retry=settings.IMPORT_UPDATE_MANY_RETRY_COUNT)
 async def import_many(
-    external_data_source_id: str, member_ids: list[str], request_id: str = None
+    external_data_source_id: str, members: list, request_id: str = None
 ):
     from hub.models import ExternalDataSource
 
     await ExternalDataSource.deferred_import_many(
         external_data_source_id=external_data_source_id,
-        member_ids=member_ids,
+        members=members,
         request_id=request_id,
     )
 

--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -337,23 +337,20 @@ LOGGING = {
         "common": {
             "format": "{levelname} {asctime} {name}.{funcName}:{lineno} # {message}",
             "style": "{",
-            "validate": True
+            "validate": True,
         },
         "procrastinate": {
             "format": "{levelname} {asctime} {name} # {message}",
             "style": "{",
-            "validate": True
+            "validate": True,
         },
     },
     "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "common"
-        },
+        "console": {"class": "logging.StreamHandler", "formatter": "common"},
         "procrastinate": {
             "class": "logging.StreamHandler",
-            "formatter": "procrastinate"
-        }
+            "formatter": "procrastinate",
+        },
     },
     "loggers": {
         "procrastinate": {

--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -334,17 +334,30 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "procrastinate": {"format": "%(asctime)s %(levelname)-7s %(name)s %(message)s"},
+        "common": {
+            "format": "{levelname} {asctime} {name}.{funcName}:{lineno} # {message}",
+            "style": "{",
+            "validate": True
+        },
+        "procrastinate": {
+            "format": "{levelname} {asctime} {name} # {message}",
+            "style": "{",
+            "validate": True
+        },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
+            "formatter": "common"
         },
+        "procrastinate": {
+            "class": "logging.StreamHandler",
+            "formatter": "procrastinate"
+        }
     },
     "loggers": {
         "procrastinate": {
-            "formatter": "procrastinate",
-            "handlers": ["console"],
+            "handlers": ["procrastinate"],
             "level": "DEBUG",
         },
         "django": {

--- a/utils/py.py
+++ b/utils/py.py
@@ -1,6 +1,7 @@
 import itertools
 import pprint
 from types import SimpleNamespace
+from uuid import UUID
 
 from benedict import benedict
 
@@ -135,3 +136,7 @@ def transform_dict_values_recursive(
         ]
     else:
         return transform_value_fn(value)
+
+
+def is_maybe_id(value):
+    return isinstance(value, (str, dict, UUID))


### PR DESCRIPTION
## Description
1. Changes fetch_all() to use a generator instead of fetching all members into memory
2. Changes jobs in general to pass whole member objects when possible, to avoid re-fetching

## Motivation and Context
https://linear.app/commonknowledge/issue/MAP-305/improve-action-network-performance

## How Can It Be Tested?
Add an action network task, import it, trigger updates, and ideally set up webooks and add a subscriber to check webhooks as well.