### PR TITLE
feat: ignore map layers with missing sources

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,4 @@ exclude =
     .venv
     migrations
     nextjs
+    node_modules


### PR DESCRIPTION
So that reports will still load even if the data source has been removed. Then the user can modify them, instead of the page crashing.