### PR TITLE
fix: limit date parsing to en-GB locales

### DIFF
--- a/hub/graphql/extensions/analytics.py
+++ b/hub/graphql/extensions/analytics.py
@@ -1,21 +1,9 @@
-from django.http import HttpRequest
+import logging
 
 import posthog
-from asgiref.sync import sync_to_async
-from gqlauth.core.middlewares import get_user_or_error
-from gqlauth.core.utils import app_settings
-from graphql import ExecutionResult as GraphQLExecutionResult, OperationType
-from graphql.error import GraphQLError
 from strawberry.extensions import SchemaExtension
-from strawberry_django.auth.utils import get_current_user
 
-
-
-from django.http import HttpRequest
-
-import posthog
-import strawberry
-from strawberry.extensions import SchemaExtension
+logger = logging.getLogger(__name__)
 
 
 class APIAnalyticsExtension(SchemaExtension):
@@ -44,4 +32,4 @@ class APIAnalyticsExtension(SchemaExtension):
                     posthog.identify(user.id, {"email": user.email})
                     posthog.capture(user.id, "API request", payload)
         except Exception as e:
-            pass
+            logger.error(f"API Analytics Extension error: {e}")

--- a/hub/graphql/extensions/api_blacklist.py
+++ b/hub/graphql/extensions/api_blacklist.py
@@ -1,8 +1,7 @@
 from django.http import HttpRequest
 
-import strawberry
-from strawberry.exceptions import StrawberryGraphQLError
 from gqlauth.core.utils import app_settings
+from strawberry.exceptions import StrawberryGraphQLError
 from strawberry.extensions import SchemaExtension
 
 from hub.models import APIToken, get_api_token

--- a/hub/tests/test_source_parser.py
+++ b/hub/tests/test_source_parser.py
@@ -7,6 +7,7 @@ from utils.py import parse_datetime
 
 class TestSourceParser(TestCase):
     dates_that_should_work = [
+        ["01/06/2024, 09:30", datetime(2024, 6, 1, 9, 30, tzinfo=timezone.utc)],
         ["15/06/2024, 09:30", datetime(2024, 6, 15, 9, 30, tzinfo=timezone.utc)],
         ["15/06/2024, 09:30:00", datetime(2024, 6, 15, 9, 30, 0, tzinfo=timezone.utc)],
         ["2023-12-20 06:00:00", datetime(2023, 12, 20, 6, 0, 0, tzinfo=timezone.utc)],

--- a/utils/py.py
+++ b/utils/py.py
@@ -184,7 +184,7 @@ def parse_datetime(value):
             parsed = dateparse.parse_datetime(value)
             if parsed is not None:
                 return parsed
-            parsed = dateparser.parse(value)
+            parsed = dateparser.parse(value, locales=["en-GB"])
             if parsed is not None:
                 return parsed
         except ValueError:


### PR DESCRIPTION
Our date parsing was assuming an American formatted date when valid (e.g. 1/2/2024 was 2nd of January 2024) 🤢  