### PR TITLE
fix: event date formatting, poetry install in devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV INSIDE_DOCKER=1 \
     PYSETUP_PATH="/opt/pysetup" \
     SHELL=/bin/bash
 RUN apt-get update && apt-get install -y \
-    binutils gdal-bin libproj-dev git npm \
+    binutils gdal-bin libproj-dev git npm python3-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sSL https://install.python-poetry.org | python -
 ENV PATH="/root/.local/bin:$PATH"

--- a/hub/graphql/schema.py
+++ b/hub/graphql/schema.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 import strawberry
 import strawberry_django
 from gqlauth.core.middlewares import JwtSchema
+from gqlauth.core.types_ import GQLAuthError
 from gqlauth.user import arg_mutations as auth_mutations
 from gqlauth.user.queries import UserQueries
 from graphql import GraphQLError
@@ -208,6 +209,7 @@ class Mutation:
 
 class CustomErrorLoggingSchema(JwtSchema):
     errors_to_ignore: List[type[Exception]] = [
+        GQLAuthError,
         PermissionDenied,
         ObjectDoesNotExist,
     ]

--- a/hub/models.py
+++ b/hub/models.py
@@ -3510,7 +3510,7 @@ class EditableGoogleSheetsSource(ExternalDataSource):
         sheet = self.sheet
         url = self.spreadsheet["spreadsheetUrl"]
         params = {"gid": sheet["properties"]["sheetId"]}
-        return f"{url}?{urlencode(params)}"
+        return f"{url}#{urlencode(params)}"
 
     def healthcheck(self):
         if self.headers:

--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -114,7 +114,7 @@ ELECTORAL_COMMISSION_API_KEY = env("ELECTORAL_COMMISSION_API_KEY")
 FRONTEND_BASE_URL = (
     env("FRONTEND_BASE_URL")
     if environment != "production"
-    else env("FRONTEND_BASE_URL")
+    else env("PROD_FRONTEND_BASE_URL")
 )
 BACKEND_URL = env("BASE_URL") if environment != "production" else env("PROD_BASE_URL")
 BASE_URL = BACKEND_URL

--- a/nextjs/src/app/(app)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(app)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -118,7 +118,6 @@ export default function Page({
   }, [context])
 
   const RNN_ORIG = Symbol();
-  const urlParams = new URLSearchParams(window ? window.location.search : "");
 
   const defaultValues: CreateExternalDataSourceInput & ExternalDataSourceInput = {
     name: '',
@@ -139,7 +138,7 @@ export default function Page({
       groupSlug: ''
     },
     editablegooglesheets: {
-      redirectSuccessUrl: urlParams.get("state") && urlParams.get("code") ? window.location.href : '',
+      redirectSuccessUrl: '',
       spreadsheetId: '',
       sheetName: '',
     },
@@ -153,6 +152,13 @@ export default function Page({
       ...defaultValues
     } as FormInputs,
   });
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(typeof window === "undefined" ? "" : window.location.search)
+    if (urlParams.get("state") && urlParams.get("code")) {
+      form.setValue('editablegooglesheets.redirectSuccessUrl', window.location.href)
+    }
+  }, [form])
 
   const dataType = form.watch("dataType") as DataSourceType
   const collectFields = useMemo(() => {

--- a/nextjs/src/app/(auth)/account/verify/page.tsx
+++ b/nextjs/src/app/(auth)/account/verify/page.tsx
@@ -18,7 +18,7 @@ export default function Verify() {
 
     useEffect(() => {
         clearJwt(); // Clear existing JWT in case user was logged in as someone else
-        const urlParams = new URLSearchParams(window ? window.location.search : "");
+        const urlParams = new URLSearchParams(typeof window === "undefined" ? "" : window.location.search)
         const token = urlParams.get('token');
         doVerify({ variables: { token } })
     }, [doVerify])

--- a/nextjs/src/components/hub/EventCard.tsx
+++ b/nextjs/src/components/hub/EventCard.tsx
@@ -9,6 +9,9 @@ export function EventCard ({ event }: {
 }) {
     const isFuture = useMemo(() => isAfter(new Date(event.startTime), new Date()), [event.startTime])
     const ctx = useHubRenderContext()
+    // The timezone must be removed, because it is not correct
+    // (it is always UTC, so ends with Z or +00:00, but it is typically in Europe/London time)
+    const startTimeWithoutTimezone = event.startTime?.split('+')[0].replace('Z', '');
 
     return (
         <article
@@ -16,14 +19,14 @@ export function EventCard ({ event }: {
         >
             <header>
                 <div className="text-meepGray-500">
-                {formatRelative(new Date(event.startTime), new Date())}
+                {formatRelative(new Date(startTimeWithoutTimezone), new Date())}
                 </div>
                 <h3 className="font-bold text-lg">{event.title}</h3>
             </header>
             <main className="space-y-3">
                 <section>
                 <div className="text-meepGray-500 text-sm">Date/Time</div>
-                <div>{formatDate(event.startTime, "EE do MMM hh:mm")}</div>
+                <div>{formatDate(startTimeWithoutTimezone, "EE do MMM HH:mm")}</div>
                 </section>
                 <section>
                 <div className="text-meepGray-500 text-sm">Address</div>


### PR DESCRIPTION
- Event dates were being parsed in UTC but formatted in local time. They either need to be parsed in the correct timezone and formatted in local time, or parsed and formatted in the same timezone. The latter was easier, so that's what is done here.
- The Docker container seemed to need `python3-dev` to install `libsass` in the dev container.