### PR TITLE
MAP-434 - Surface Address Picker In Data Mapping 

### DIFF
--- a/hub/enrichment/sources/__init__.py
+++ b/hub/enrichment/sources/__init__.py
@@ -211,6 +211,11 @@ builtin_mapping_sources = {
                 "value": "dates[0].polling_station.station.id",
                 "label": "Nearest Polling Station ID",
             },
+            {
+                "value": "address_picker", 
+                "label": "Address Picker",
+                "description": "True if we need to show this user an address picker, as their postcode has more than one polling station"
+            },
         ],
     },
 }

--- a/hub/enrichment/sources/__init__.py
+++ b/hub/enrichment/sources/__init__.py
@@ -214,7 +214,7 @@ builtin_mapping_sources = {
             {
                 "value": "address_picker", 
                 "label": "Address Picker",
-                "description": "True if we need to show this user an address picker, as their postcode has more than one polling station"
+                "description": "True if we need to show this user an address picker, as their postcode has more than one polling station",
             },
         ],
     },

--- a/hub/enrichment/sources/__init__.py
+++ b/hub/enrichment/sources/__init__.py
@@ -212,7 +212,7 @@ builtin_mapping_sources = {
                 "label": "Nearest Polling Station ID",
             },
             {
-                "value": "address_picker", 
+                "value": "address_picker",
                 "label": "Address Picker",
                 "description": "True if we need to show this user an address picker, as their postcode has more than one polling station",
             },


### PR DESCRIPTION
This allows the user to select the address picker when they map data across to a third party data source.

## Description
<!--- Describe your changes in detail -->

In some situations, a postcode has ambiguous polling stations. In other implementations of this data set, the user is shown a dropdown so they can choose their specific address. We obviously can't do that when writing data across, so need to just allow CRMs to know this so they can show the user another path to find out their polling location.

See https://api.electoralcommission.org.uk/docs/endpoints/#postcode-search-results-found-3 for a situation where results are found.

See https://api.electoralcommission.org.uk/docs/endpoints/#postcode-search-address-picker-3 for a situation where a data picker is displayed.

It is useful to know this in, say, Action Network, to make decisions on what is shown in email templates. Imagining here we map over to an Action Network custom field called `Polling Station Known`.

```liquid

{% if 'Polling Station Known' != "false" %}

Your polling station is:

{{ 'Nearest Polling Station Address' | form_value }}

Get Directions

{% else %}

Hit the link below to find your polling station:

...

{% endif %}
```

## How Can It Be Tested?
<!--- Please describe in detail how you tested your changes so that a reviewer can reproduce the results. -->
<!--- Include details of your testing environment, and the tests you've run your self -->
<!--- see how your change affects other areas of the code, etc. -->

1. Roll it out.
2. Add in the data source as required and test manually.

## How Will This Be Deployed?
<!--- Run through any change to infrastructure, CLI commands or manual admin config to do -->
<!--- For example, any env variables to add to the hosting infra? -->

Usual continuous delivery process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- My change requires a change to the documentation.
- I've updated the documentation accordingly.
- [x] Replace unused checkboxes with bullet points.