### PR TITLE
feat: import 2024 MPs

### DIFF
--- a/hub/fixtures/areas.json
+++ b/hub/fixtures/areas.json
@@ -51,6 +51,39 @@
       "area_type_id": 1,
       "geometry": "{\"name\": \"Borsetshire East\", \"properties\": {}}"
     }
+  },
+  {
+    "model": "hub.area",
+    "pk": 4,
+    "fields": {
+      "gss": "E10000011",
+      "mapit_id": "4",
+      "name": "New South Borsetshire",
+      "area_type_id": 2,
+      "geometry": "{\"name\": \"New South Borsetshire\", \"properties\": {}}"
+    }
+  },
+  {
+    "model": "hub.area",
+    "pk": 5,
+    "fields": {
+      "gss": "E10000012",
+      "mapit_id": "5",
+      "name": "New Borsetshire West",
+      "area_type_id": 2,
+      "geometry": "{\"name\": \"New Borsetshire West\", \"properties\": {}}"
+    }
+  },
+  {
+    "model": "hub.area",
+    "pk": 6,
+    "fields": {
+      "gss": "E10000013",
+      "mapit_id": "6",
+      "name": "New Borsetshire East",
+      "area_type_id": 2,
+      "geometry": "{\"name\": \"New Borsetshire East\", \"properties\": {}}"
+    }
   }
 ]
 

--- a/hub/graphql/types/model_types.py
+++ b/hub/graphql/types/model_types.py
@@ -709,7 +709,8 @@ class Analytics:
         data = self.imported_data_count_by_area(
             postcode_io_key=analytical_area_type.value
         )
-        return [GroupedDataCount(**datum) for datum in data]
+        area_key = postcodeIOKeyAreaTypeLookup[analytical_area_type]
+        return [GroupedDataCount(**datum, area_type=area_key) for datum in data]
 
     @strawberry_django.field
     def imported_data_count_for_area(
@@ -1181,8 +1182,12 @@ def public_map_report(info: Info, org_slug: str, report_slug: str) -> models.Map
 
 
 @strawberry_django.field()
-def area_by_gss(gss: str) -> models.Area:
-    return models.Area.objects.get(gss=gss)
+def area_by_gss(gss: str, analytical_area_type: AnalyticalAreaType) -> models.Area:
+    qs = models.Area.objects.all()
+    if analytical_area_type:
+        area_key = postcodeIOKeyAreaTypeLookup[analytical_area_type]
+        qs = qs.filter(area_type__code=area_key)
+    return qs.get(gss=gss)
 
 
 @strawberry_django.field()

--- a/hub/management/commands/import_mps.py
+++ b/hub/management/commands/import_mps.py
@@ -61,7 +61,7 @@ MP_IMPORT_COMMANDS = [
 class Command(BaseCommand):
     help = "Import UK Members of Parliament"
 
-    area_type = "WMC"
+    area_type = "WMC23"
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/hub/management/commands/import_mps.py
+++ b/hub/management/commands/import_mps.py
@@ -233,9 +233,10 @@ class Command(BaseCommand):
         for _, mp in tqdm(data.iterrows(), disable=self._quiet, total=data.shape[0]):
             area = Area.get_by_name(mp["Constituency"], area_type=self.area_type)
             if area is None:  # pragma: no cover
+                mp_dict = mp.to_dict()
                 print(
-                    "Failed to add MP {} as area {} does not exist" % mp["personLabel"],
-                    mp["gss_code"],
+                    f"Failed to add MP {mp_dict.get('personLabel')} as area "
+                    f"{mp_dict.get('Constituency')} / {mp_dict.get('gss_code')} does not exist"
                 )
                 continue
 

--- a/hub/tests/test_import_mps.py
+++ b/hub/tests/test_import_mps.py
@@ -45,7 +45,7 @@ class ImportMPsTestCase(TestCase):
                     },
                     {
                         "twfyid": {"value": 27},
-                        "gss_code": {"value": "E10000002"},
+                        "gss_code": {"value": "E10000012"},
                         "personLabel": {"value": "Angela Madeupname"},
                         "partyLabel": {"value": "Borsetshire Unionist"},
                     },
@@ -59,7 +59,7 @@ class ImportMPsTestCase(TestCase):
                     26,
                     27,
                 ],
-                "Constituency": ["South Borsetshire", "Borsetshire West"],
+                "Constituency": ["New South Borsetshire", "New Borsetshire West"],
                 "Party": ["Borsetshire Independence", "Borsetshire Unionist"],
                 "First name": ["James", "Angela"],
                 "Last name": ["Madeupname", "Madeupname"],

--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -346,28 +346,34 @@ class TestAreaSearchPage(TestCase):
 
     def test_area_name_lookup(self):
         url = reverse("area_search")
-        response = self.client.get(url, {"search": "South Borsetshire"}, follow=True)
+        response = self.client.get(
+            url, {"search": "New South Borsetshire"}, follow=True
+        )
 
-        self.assertRedirects(response, "/area/WMC/South%20Borsetshire")
+        self.assertRedirects(response, "/area/WMC23/New%20South%20Borsetshire")
         self.assertTemplateUsed(response, "hub/area.html")
 
         context = response.context
-        self.assertEqual(context["area"].name, "South Borsetshire")
+        self.assertEqual(context["area"].name, "New South Borsetshire")
 
     def test_search_with_spaces(self):
         url = reverse("area_search")
-        response = self.client.get(url, {"search": " South Borsetshire"}, follow=True)
+        response = self.client.get(
+            url, {"search": " New South Borsetshire"}, follow=True
+        )
 
-        self.assertRedirects(response, "/area/WMC/South%20Borsetshire")
+        self.assertRedirects(response, "/area/WMC23/New%20South%20Borsetshire")
         self.assertTemplateUsed(response, "hub/area.html")
 
-        response = self.client.get(url, {"search": "South Borsetshire "}, follow=True)
+        response = self.client.get(
+            url, {"search": "New South Borsetshire "}, follow=True
+        )
 
-        self.assertRedirects(response, "/area/WMC/South%20Borsetshire")
+        self.assertRedirects(response, "/area/WMC23/New%20South%20Borsetshire")
         self.assertTemplateUsed(response, "hub/area.html")
 
         context = response.context
-        self.assertEqual(context["area"].name, "South Borsetshire")
+        self.assertEqual(context["area"].name, "New South Borsetshire")
 
     def test_mp_name_lookup(self):
         url = reverse("area_search")
@@ -398,7 +404,7 @@ class TestAreaSearchPage(TestCase):
         self.assertTemplateUsed(response, "hub/area_search.html")
 
         context = response.context
-        self.assertEqual(len(context["areas"]), 3)
+        self.assertEqual(len(context["areas"]), 6)
 
 
 class testUserFavouriteViews(TestCase):

--- a/nextjs/src/components/reportsConstituencyItem.tsx
+++ b/nextjs/src/components/reportsConstituencyItem.tsx
@@ -370,7 +370,7 @@ export const ConstituencyElectionCard = ({
 
 const CONSTITUENCY_DATA = gql`
   query GetConstituencyData($analyticalAreaType: AnalyticalAreaType!, $gss: String!, $reportID: ID!) {
-    constituency: area(gss: $gss) {
+    constituency: area(gss: $gss, analyticalAreaType: $analyticalAreaType) {
       id
       name
       mp: person(filters:{personType:"MP"}) {


### PR DESCRIPTION
## Description
Updates the `import_mps` command to link MPs to the 2024 constituency `Areas`.

## How Can It Be Tested?
Checkout the branch. Run `python manage.py import_mps`. Check the correct MP is visible
in the report.

## How Will This Be Deployed?
Need to run the above command after deployment. We may need to delete existing MPs first.