### PR TITLE
Pass postcode to Loudspeek e-action form from search form input 

### DIFF
--- a/nextjs/src/app/hub/render/[hostname]/map/SearchPanel.tsx
+++ b/nextjs/src/app/hub/render/[hostname]/map/SearchPanel.tsx
@@ -6,12 +6,15 @@ import { FormEvent, useState } from "react"
 
 export function SearchPanel({
   onSearch,
-  isLoading
+  isLoading,
+  postcode,
+  setPostcode
 }: {
   onSearch: (postcode: string) => void,
-  isLoading: boolean
+  isLoading: boolean,
+  postcode: string,
+  setPostcode: React.Dispatch<React.SetStateAction<string>>
 }) {
-  const [postcode, setPostcode] = useState("")
   const onSubmit = (e: FormEvent) => {
     e.preventDefault()
     const sanitisedPostcode = postcode.replace(/([\s ]*)/mig, "").trim()
@@ -67,12 +70,12 @@ export function SearchPanel({
             type="text"
             placeholder="postcode"
             autoComplete="postal-code"
-            className='p-4 text-lg w-full rounded-md border focus:ring-hub-secondary-500 active:border-hub-secondary-500 text-black'
+            className='p-4 text-lg w-full rounded-md border placeholder:text-hub-primary-600 focus:ring-hub-primary-600 bg-hub-primary-50 border-hub-primary-100 mt-4 active:border-hub-primary-500'
             value={postcode}
             onChange={e => setPostcode(e.target.value.toUpperCase().trim())}
           />
           <button
-            className='bg-hub-secondary-500 text-white text-lg font-bold rounded-md w-full p-4 mt-4'
+            className='bg-hub-primary-600 text-white text-lg font-bold rounded-md w-full p-4 mt-4'
             // TODO: add postcode validation
             disabled={!postcode || isLoading}
           >
@@ -84,7 +87,7 @@ export function SearchPanel({
   }
 }
 
-export function HustingsCTA () {
+export function HustingsCTA() {
   return (
     <>
       <p>
@@ -92,7 +95,7 @@ export function HustingsCTA () {
       </p>
       <Link href="https://docs.google.com/forms/d/e/1FAIpQLSeQ6L2fko9q1xNvEYt0ZNbIIPDNAq6cs93Pn2Vx8ARtMf6FIg/viewform" target="_blank" className="">
         <Button className="bg-white border border-hub-primary-600 text-hub-primary-600 gap-2 hover:bg-hub-primary-50">
-          <Plus/>
+          <Plus />
           Add Event
         </Button>
       </Link>

--- a/nextjs/src/app/hub/render/[hostname]/map/page.tsx
+++ b/nextjs/src/app/hub/render/[hostname]/map/page.tsx
@@ -1,7 +1,6 @@
-// page.js
 "use client";
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useQuery } from "@apollo/client";
@@ -28,14 +27,17 @@ export default function Page(props: { params: Params }) {
     variables: { hostname: props.params.hostname },
   });
 
-  const shouldDisplayMap = useBreakpoint("md")
+  const shouldDisplayMap = useBreakpoint("md");
+
+  const [postcode, setPostcode] = useState("");
+  console.log(postcode)
 
   return (
     <JotaiProvider>
       <HubRenderContextProvider hostname={props.params.hostname}>
         <Root renderCSS={false} fullScreen={shouldDisplayMap} navLinks={hub.data?.hubByHostname?.navLinks || []}>
           <MapProvider>
-            <PageContent {...props} shouldDisplayMap={shouldDisplayMap} hub={hub.data} />
+            <PageContent {...props} shouldDisplayMap={shouldDisplayMap} hub={hub.data} postcode={postcode} setPostcode={setPostcode} />
           </MapProvider>
         </Root>
       </HubRenderContextProvider>
@@ -43,8 +45,8 @@ export default function Page(props: { params: Params }) {
   );
 }
 
-function PageContent ({ params: { hostname }, shouldDisplayMap, hub }: { params: Params, shouldDisplayMap: boolean, hub?: GetHubMapDataQuery }) {
-  const hubContext = useHubRenderContext()
+function PageContent ({ params: { hostname }, shouldDisplayMap, hub, postcode, setPostcode }: { params: Params, shouldDisplayMap: boolean, hub?: GetHubMapDataQuery, postcode: string, setPostcode: React.Dispatch<React.SetStateAction<string>> }) {
+  const hubContext = useHubRenderContext();
 
   const localData = useQuery<GetLocalDataQuery, GetLocalDataQueryVariables>(GET_LOCAL_DATA, {
     variables: { postcode: hubContext.postcode!, hostname },
@@ -80,14 +82,16 @@ function PageContent ({ params: { hostname }, shouldDisplayMap, hub }: { params:
               >
                 <div className="max-w-[100vw] rounded-[20px] bg-white max-h-full overflow-y-auto  pointer-events-auto">
                   {hubContext.eventId && eventData.data ? (
-                    <ConstituencyView data={eventData.data?.importedDataGeojsonPoint?.properties?.constituency} />
+                    <ConstituencyView data={eventData.data?.importedDataGeojsonPoint?.properties?.constituency} postcode={postcode} />
                   ) : !localData.data ? (
                     <SearchPanel
                       onSearch={(postcode) => hubContext.goToPostcode(postcode)}
                       isLoading={localData.loading}
+                      postcode={postcode}
+                      setPostcode={setPostcode}
                     />
                   ) : (
-                    <ConstituencyView data={localData.data?.postcodeSearch.constituency} />
+                    <ConstituencyView data={localData.data?.postcodeSearch.constituency} postcode={postcode} />
                   )}
                 </div>
               </aside>
@@ -100,9 +104,11 @@ function PageContent ({ params: { hostname }, shouldDisplayMap, hub }: { params:
             <SearchPanel
               onSearch={(postcode) => hubContext.goToPostcode(postcode)}
               isLoading={localData.loading}
+              postcode={postcode}
+              setPostcode={setPostcode}
             />
           ) : (
-            <ConstituencyView data={localData.data.postcodeSearch.constituency} />
+            <ConstituencyView data={localData.data.postcodeSearch.constituency} postcode={postcode} />
           )}
         </div>
       )}

--- a/nextjs/src/app/hub/render/[hostname]/map/page.tsx
+++ b/nextjs/src/app/hub/render/[hostname]/map/page.tsx
@@ -30,7 +30,6 @@ export default function Page(props: { params: Params }) {
   const shouldDisplayMap = useBreakpoint("md");
 
   const [postcode, setPostcode] = useState("");
-  console.log(postcode)
 
   return (
     <JotaiProvider>

--- a/nextjs/src/components/hub/ConstituencyView.tsx
+++ b/nextjs/src/components/hub/ConstituencyView.tsx
@@ -27,7 +27,6 @@ export function ConstituencyView({
 }) {
   const [tab, setTab] = useState("candidates");
   const hubContext = useHubRenderContext();
-  console.log('postcode', postcode)
 
   if (!data?.name) {
     return (

--- a/nextjs/src/components/hub/ConstituencyView.tsx
+++ b/nextjs/src/components/hub/ConstituencyView.tsx
@@ -19,13 +19,16 @@ import { BACKEND_URL } from "@/env";
 import { EventCard } from "./EventCard";
 
 export function ConstituencyView({
-  data
+  data,
+  postcode
 }: {
-  data: GetLocalDataQuery["postcodeSearch"]["constituency"];
+  data: GetLocalDataQuery["postcodeSearch"]["constituency"],
+  postcode: string
 }) {
   const [tab, setTab] = useState("candidates");
   const hubContext = useHubRenderContext();
-  
+  console.log('postcode', postcode)
+
   if (!data?.name) {
     return (
       <div className="p-6">
@@ -64,11 +67,6 @@ export function ConstituencyView({
     // future events
     isBefore(new Date(e.startTime), new Date())
   );
-
-
-  const postcode = data?.samplePostcode?.postcode
-    ?.trim()
-    .replace(/([\s ]*)/gim, "");
 
   return (
     <div className="flex flex-col overflow-y-hidden">


### PR DESCRIPTION
## Description
This PR passes the search input value into the query string for Loudspeek
https://peopleclimatenature.onldspk.cc/2024-mps/frame/write
This is because for some postcodes samplePostcode was null in the constituency data that was being returned from the API.
As we are only using it for Loudspeek it seemed worthwhile to simplify this. 

## Motivation and Context
Addresses issue [CC-185](https://linear.app/commonknowledge/issue/CC-185/there-is-an-additional-step-in-the-e-action-for-some-postcodes)

## How Can It Be Tested?
Download the branch and run locally
Go to the map page and search by postcode e.g. http://hub.localhost:3000/map?postcode={postcode}
Test the following postcodes and observe that they return the MP straight away rather than an intermediate search being needed (unlike on the live site)
BA2 8LZ 
BA10 0JW
YO42 4TR

## How Will This Be Deployed?
Normal deployment process

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

