### PR TITLE
Add rich text editor puck cms

### DIFF
--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -81,6 +81,7 @@
         "react-hook-form": "^7.51.0",
         "react-loader-spinner": "^6.1.6",
         "react-map-gl": "^7.1.7",
+        "react-quill": "^2.0.0",
         "react-simple-code-editor": "^0.13.1",
         "slug": "^9.1.0",
         "sonner": "^1.4.3",
@@ -5834,6 +5835,14 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.2.61",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.61.tgz",
@@ -10798,6 +10807,25 @@
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
       "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -10885,7 +10913,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -12087,6 +12114,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+    },
     "node_modules/exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -12455,6 +12487,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "node_modules/fast-equals": {
       "version": "5.0.1",
@@ -12952,7 +12989,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16088,7 +16124,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18704,11 +18739,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -19145,6 +19194,11 @@
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -20271,6 +20325,40 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/raf-schd": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
@@ -20492,6 +20580,20 @@
         "maplibre-gl": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/react-redux": {
@@ -20761,7 +20863,6 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -21606,7 +21707,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -86,6 +86,7 @@
     "react-hook-form": "^7.51.0",
     "react-loader-spinner": "^6.1.6",
     "react-map-gl": "^7.1.7",
+    "react-quill": "^2.0.0",
     "react-simple-code-editor": "^0.13.1",
     "slug": "^9.1.0",
     "sonner": "^1.4.3",

--- a/nextjs/src/data/puck/config/blocks/RichText/customRichTextStyles.css
+++ b/nextjs/src/data/puck/config/blocks/RichText/customRichTextStyles.css
@@ -1,0 +1,25 @@
+ul {
+    list-style-type: disc;
+    padding-left: 24px;
+}
+
+ol {
+    list-style-type: decimal;
+    padding-left: 24px;
+}
+
+a {
+    text-decoration: underline;
+}
+
+.size-small {
+    font-size: 16px;  
+}
+
+.size-medium {
+    font-size: 20px; 
+}
+
+.size-large {
+    font-size: 24px; 
+}

--- a/nextjs/src/data/puck/config/blocks/RichText/index.tsx
+++ b/nextjs/src/data/puck/config/blocks/RichText/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { ComponentConfig } from "@measured/puck";
+import ReactQuill, { Quill } from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import './customRichTextStyles.css';
+
+const Parchment = Quill.import('parchment');
+const SizeClass = new Parchment.Attributor.Class('size', 'size', {
+    scope: Parchment.Scope.INLINE,
+    whitelist: ['small', 'medium', 'large']
+});
+Quill.register(SizeClass, true);
+
+export type RichTextProps = {
+    content: string
+};
+
+const modules = {
+    toolbar: [
+        [{ 'size': ['small', 'medium', 'large' ] }], 
+        [ 'italic', 'underline', 'strike'],
+        [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+        ['link'],
+        ['clean']
+    ],
+};
+
+const formats = [
+    'size', 'italic', 'underline', 'strike',
+    'list', 'bullet', 'link'
+];
+
+export const RichText: ComponentConfig<RichTextProps> = {
+    label: "RichText",
+    fields: {
+        content: {
+            type: "custom",
+            render: ({ onChange, value }) => (
+                <ReactQuill
+                    value={value}
+                    onChange={(e: string) => onChange(e)}
+                    modules={modules}
+                    formats={formats}
+                />
+            ),
+        }
+    },
+    render: ({ content }) => {
+        return (
+            <div className='max-w-prose'
+                dangerouslySetInnerHTML={{ __html: content }}
+            />
+        );
+    },
+};

--- a/nextjs/src/data/puck/config/index.tsx
+++ b/nextjs/src/data/puck/config/index.tsx
@@ -1,5 +1,4 @@
 import { Config } from "@measured/puck";
-import { PuckRichText } from "@tohuhono/puck-rich-text"
 import Root, { RootProps } from "./root";
 import { ButtonGroup, ButtonGroupProps } from "./blocks/ButtonGroup";
 import { Card, CardProps } from "./blocks/Card";
@@ -21,6 +20,7 @@ import { Image, ImageProps } from "./blocks/Image";
 import { HomepageItemsAlias } from "./blocks/HomepageItemsAlias";
 import { About } from "./blocks/About";
 import { HTMLEmbed, HTMLEmbedProps } from "./blocks/HTMLEmbed";
+import { RichText, RichTextProps } from "./blocks/RichText";
 import { Iframe, IframeProps } from "./blocks/Iframe";
 
 export type Props = {
@@ -44,7 +44,8 @@ export type Props = {
   HomepageItemsAlias: any;
   About: any;
   HTMLEmbed: HTMLEmbedProps;
-  Iframe: IframeProps
+  Iframe: IframeProps;
+  RichText: RichTextProps
 };
 
 export type UserConfig = Config
@@ -121,7 +122,7 @@ export const conf: UserConfig = {
     EventList,
     Image,
     HomepageItemsAlias,
-    RichText: PuckRichText,
+    RichText,
     About,
     HTMLEmbed,
     Iframe

--- a/nextjs/src/data/puck/config/index.tsx
+++ b/nextjs/src/data/puck/config/index.tsx
@@ -100,7 +100,6 @@ export const conf: UserConfig = {
     },
     content: {
       components: [
-        "Text",
         "RichText",
         "HTMLEmbed",
         "Iframe",


### PR DESCRIPTION
## Description
This PR 
- removes a unnecessary Text Block that was crashing the editor
- adds a custom Rich Text component using React Quill 

## Motivation and Context
Addresses issue [CC-187](https://linear.app/commonknowledge/issue/CC-187/cannot-edit-richtext-block-in-puck-editor)
There was a bug with the existing [Puck Rich Text Component](https://www.npmjs.com/package/@tohuhono/puck-rich-text)(details are in the Linear ticket)

## How Can It Be Tested?
Download the branch and run locally
Navigate http://localhost:3000/hub/editor/ 
Add a RichText block to the page
Apply styles to the text
Publish and see on the page


## How Will This Be Deployed?
Normal deployment process

## Screenshots (if appropriate):
![Untitled1](https://github.com/user-attachments/assets/0588477b-2dc3-410b-b740-2c965ecdf341)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
