### PR TITLE
feat: display hub map on mobile

### DIFF
--- a/nextjs/src/app/hub/render/[hostname]/map/SearchPanel.tsx
+++ b/nextjs/src/app/hub/render/[hostname]/map/SearchPanel.tsx
@@ -27,9 +27,15 @@ export function SearchPanel({
     const disabled = !postcode || isLoading
     return (
       <div className="flex flex-col gap-6 p-6">
-        <h1 className='text-4xl tracking-tight '>
-          Pledge to take part in Common Grounds
-        </h1>
+        <div className="flex gap-4">
+          <div className="md:hidden flex flex-col bg-meepGray-100 py-1 px-4 text-center rounded">
+            <span>OCT</span>
+            <span className="text-2xl">12</span>
+          </div>
+          <h1 className='text-2xl md:text-4xl tracking-tight '>
+            Pledge to take part in Common Grounds
+          </h1>
+        </div>
         <p className='text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
           We are inviting as many people and communities as possible across the UK to meet with their MP in their local area.
         </p>
@@ -63,7 +69,7 @@ export function SearchPanel({
     // Unbranded
     return (
       <div className="flex flex-col gap-4 p-6">
-        <h1 className='text-4xl tracking-tight mb-4 text-hub-primary-500'>
+        <h1 className='text-2xl md:text-4xl tracking-tight mb-4 text-hub-primary-500'>
           Upcoming events
         </h1>
         <p className='text-lg leading-tight text-hub-primary-neutral'>

--- a/nextjs/src/app/hub/render/[hostname]/map/SearchPanel.tsx
+++ b/nextjs/src/app/hub/render/[hostname]/map/SearchPanel.tsx
@@ -36,13 +36,13 @@ export function SearchPanel({
             Pledge to take part in Common Grounds
           </h1>
         </div>
-        <p className='text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
+        <p className='text-[17px] md:text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
           We are inviting as many people and communities as possible across the UK to meet with their MP in their local area.
         </p>
-        <p className='text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
+        <p className='text-[17px] md:text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
           Through personal stories and discussions about the issues that matters most, we aim to inspire MPs to champion nature and climate issues alongside us.
         </p>
-        <p className='text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
+        <p className='text-[17px] md:text-lg leading-tight text-hub-primary-neutral text-meepGray-500'>
           Enter your postcode to find your MP and pledge to meet with them on 12 October.
         </p>
         <form onSubmit={onSubmit}>

--- a/nextjs/src/components/hub/ConstituencyView.tsx
+++ b/nextjs/src/components/hub/ConstituencyView.tsx
@@ -80,7 +80,7 @@ export function ConstituencyView({
         >
           &larr; Search another postcode
         </a>
-        <h2 className="text-3xl text-hub-primary-950 font-bold">
+        <h2 className="text-2xl md:text-3xl text-hub-primary-950 font-bold">
           {data?.name}
         </h2>
       </header>

--- a/nextjs/src/data/puck/config/root.tsx
+++ b/nextjs/src/data/puck/config/root.tsx
@@ -61,7 +61,7 @@ export default function Root({
           </header>
           <div
             className={twMerge(
-              "rounded-2xl",
+              "rounded-t-2xl md:rounded-2xl",
               fullScreen && "h-full flex-grow mb-2 md:mb-4 overflow-hidden",
             )}
           >


### PR DESCRIPTION
A very simple implementation of the design here: https://www.figma.com/proto/kxiLho8sEr4YRyyS5DjrhD/Climate-Coalition-2024-Election-Hub-(Post-Launch-Design)?page-id=3136%3A1586&node-id=3136-1990&node-type=canvas&viewport=720%2C218%2C0.07&t=ewfvCrZ0AqAHJZCQ-8&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=3136%3A1990&show-proto-sidebar=1&hide-ui=1

To get something out fast!

It just scrolls:

<img width="431" alt="image" src="https://github.com/user-attachments/assets/fdc56c21-a77c-41d4-a5db-677cc36d7b95">

<img width="422" alt="image" src="https://github.com/user-attachments/assets/ea3c7cdf-b057-4468-9e82-4d471756c792">
