### PR TITLE
Make host machine ssh keys available to dev container 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
     8000,
     5432
   ],
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+  ],
   "postCreateCommand": "./bin/ck_setup.sh",
   "postAttachCommand": "./bin/ensure_ck_setup.sh",
   "customizations": {


### PR DESCRIPTION
## Description
This PR adds a mounts configuration to the dev container set up to allow the container to access SSH keys on the host machine e.g. for authenticating with GitHub

## Motivation and Context
Addresses issue [MAP-586](https://linear.app/commonknowledge/issue/MAP-586/fix-ssh-authentication-with-github-in-dev-container)

## How Can It Be Tested?
Download the branch and run locally
Rebuild the container if prompted
Run `ssh -T git@github.com` inside the container to test connection to GitHub
You should see a message like this
Hi <username>! You've successfully authenticated, but GitHub does not provide shell access.

