### PR TITLE
feat: add logging to password reset related mutations to debug failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       GOOGLE_SITE_VERIFICATION: ${GOOGLE_SITE_VERIFICATION:-}
       DJANGO_SUPERUSER_USERNAME: 'admin'
       DJANGO_SUPERUSER_PASSWORD: 'password'
-      DJANGO_SUPERUSER_EMAIL: 'admin@localhost'
+      DJANGO_SUPERUSER_EMAIL: 'admin@example.com'
     working_dir: /app
     # Runs app on the same network as the database container,
     # allows "forwardPorts" in devcontainer.json function

--- a/hub/graphql/auth_mutations.py
+++ b/hub/graphql/auth_mutations.py
@@ -1,0 +1,127 @@
+import logging
+from smtplib import SMTPException
+from dataclasses import asdict
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.signing import BadSignature, SignatureExpired
+
+from gqlauth.core.constants import Messages, TokenAction
+from gqlauth.core.exceptions import TokenScopeError, UserNotVerified
+from gqlauth.core.types_ import MutationNormalOutput
+from gqlauth.core.utils import (
+    get_payload_from_token,
+    get_user_by_email,
+    revoke_user_refresh_token,
+)
+from gqlauth.models import UserStatus
+from gqlauth.settings import gqlauth_settings as app_settings
+from gqlauth.user import arg_mutations as gqlauth_mutations
+from gqlauth.user.forms import EmailForm
+from gqlauth.user.signals import user_verified
+
+logger = logging.getLogger(__name__)
+
+UserModel = get_user_model()
+
+
+def user_status_str(status: UserStatus | None) -> str:
+    if not status:
+        return "None"
+    return "verified" if status.verified else "not verified"
+
+
+class SendPasswordResetEmail(gqlauth_mutations.SendPasswordResetEmail):
+    """
+    Override library mutation to add copious logging.
+    """
+
+    @classmethod
+    def resolve_mutation(
+        cls,
+        info,
+        input_: gqlauth_mutations.SendPasswordResetEmailMixin.SendPasswordResetEmailInput,
+    ) -> MutationNormalOutput:
+        logger.info(f"Password reset email requested, email: {input_.email}")
+        try:
+            email = input_.email
+            f = EmailForm({"email": email})
+            if f.is_valid():
+                logger.info("Password reset email requested, form valid")
+                user = get_user_by_email(email)
+                logger.info(f"Sending password reset email to {user}")
+                user.status.send_password_reset_email(info, [email])
+                logger.info(f"Sent password reset email to {user}")
+                return MutationNormalOutput(success=True)
+            errors = f.errors.get_json_data()
+            logger.error(f"Password reset email request failed, form invalid: {errors}")
+            return MutationNormalOutput(success=False, errors=errors)
+        except ObjectDoesNotExist:
+            logger.error(
+                f"Password reset email request failed: user {input_.email} does not exist"
+            )
+            return MutationNormalOutput(success=True)  # even if user is not registered
+        except SMTPException as e:
+            logger.error(f"Password reset email request failed: SMTPException {e}")
+            return MutationNormalOutput(success=False, errors=Messages.EMAIL_FAIL)
+        except UserNotVerified:
+            logger.error(
+                f"Password reset email request failed: user {input_.email} not verified"
+            )
+            user = get_user_by_email(input_.email)
+            try:
+                logger.info(f"Sending activation email to {user}")
+                user.status.resend_activation_email(info)
+                logger.info(f"Sent activation email to {user}")
+                return MutationNormalOutput(
+                    success=False,
+                    errors={"email": Messages.NOT_VERIFIED_PASSWORD_RESET},
+                )
+            except SMTPException as e:
+                logger.error(f"Resend activation email failed: SMTPException {e}")
+                return MutationNormalOutput(success=False, errors=Messages.EMAIL_FAIL)
+
+
+class PasswordReset(gqlauth_mutations.PasswordReset):
+    """
+    Override library mutation to add copious logging.
+    """
+
+    @classmethod
+    def resolve_mutation(
+        cls, _, input_: gqlauth_mutations.PasswordReset.PasswordResetInput
+    ) -> MutationNormalOutput:
+        logger.info(f"Password reset requested, token: {input_.token}")
+        try:
+            payload = get_payload_from_token(
+                input_.token,
+                TokenAction.PASSWORD_RESET,
+                app_settings.EXPIRATION_PASSWORD_RESET_TOKEN,
+            )
+            logger.info(f"Password reset requested, payload: {payload}")
+            user = UserModel._default_manager.get(**payload)
+            logger.info(f"Password reset requested, user: {user}")
+            status: "UserStatus" = getattr(user, "status")  # noqa: B009
+            logger.info(f"Password reset requested, user status: {user_status_str(status)}")
+            f = cls.form(user, asdict(input_))  # type: ignore
+            if f.is_valid():
+                logger.info("Password reset requested, form is valid")
+                revoke_user_refresh_token(user)
+                logger.info(f"Revoked refresh tokens for user: {user}")
+                user = f.save()  # type: ignore
+                logger.info(f"Saved new password for user: {user}")
+                if status.verified is False:
+                    status.verified = True
+                    status.save(update_fields=["verified"])
+                    logger.info(f"Marked {user} as verified")
+                    user_verified.send(sender=cls, user=user)
+
+                logger.info(f"Password reset successful for user {user}")
+                return MutationNormalOutput(success=True)
+            errors = f.errors.get_json_data()
+            logger.error(f"Password reset failed, form invalid: {errors}")
+            return MutationNormalOutput(success=False, errors=errors)
+        except SignatureExpired:
+            return MutationNormalOutput(success=False, errors=Messages.EXPIRED_TOKEN)
+        except (BadSignature, TokenScopeError):
+            return MutationNormalOutput(success=False, errors=Messages.INVALID_TOKEN)

--- a/hub/graphql/schema.py
+++ b/hub/graphql/schema.py
@@ -7,7 +7,7 @@ import strawberry
 import strawberry_django
 from gqlauth.core.middlewares import JwtSchema
 from gqlauth.core.types_ import GQLAuthError
-from gqlauth.user import arg_mutations as auth_mutations
+from gqlauth.user import arg_mutations as gqlauth_mutations
 from gqlauth.user.queries import UserQueries
 from graphql import GraphQLError
 from strawberry.extensions import QueryDepthLimiter
@@ -17,6 +17,7 @@ from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.permissions import IsAuthenticated
 
 from hub import models
+from hub.graphql import auth_mutations
 from hub.graphql import mutations as mutation_types
 from hub.graphql.extensions.analytics import APIAnalyticsExtension
 from hub.graphql.extensions.api_blacklist import APIBlacklistGuard
@@ -147,10 +148,10 @@ class Query(UserQueries):
 
 @strawberry.type
 class Mutation:
-    token_auth = auth_mutations.ObtainJSONWebToken.field
+    token_auth = gqlauth_mutations.ObtainJSONWebToken.field
     # register = auth_mutations.Register.field
-    verify_account = auth_mutations.VerifyAccount.field
-    resend_activation_email = auth_mutations.ResendActivationEmail.field
+    verify_account = gqlauth_mutations.VerifyAccount.field
+    resend_activation_email = gqlauth_mutations.ResendActivationEmail.field
     request_password_reset = auth_mutations.SendPasswordResetEmail.field
     perform_password_reset = auth_mutations.PasswordReset.field
 


### PR DESCRIPTION
## Description
Overrides the built in gqlauth mutations with duplicate code that does a lot of logging.

https://linear.app/commonknowledge/issue/MAP-459/fix-password-reset-blocking-user-onboarding