### PR TITLE
Revive area labels counts [MAP-661]

### DIFF
--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -168,7 +168,7 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
             "organisation": organisation,
             "slug": data.slug or slugify(data.name),
             "name": f"New map ({date_time_str})",  # Default name for reports
-            "display_options": data.display_options or {}
+            "display_options": data.display_options or {},
         },
     }
 

--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -166,6 +166,7 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
             "organisation": organisation,
             "slug": data.slug or slugify(data.name),
             "name": "Type your report name here",  # Default name for reports
+            "display_options": data.display_options or {}
         },
     }
 

--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -160,12 +160,14 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
     else:
         organisation = models.Organisation.get_or_create_for_user(user)
 
+    date_time_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
     params = {
         **graphql_type_to_dict(data, delete_null_keys=True),
         **{
             "organisation": organisation,
             "slug": data.slug or slugify(data.name),
-            "name": "Type your report name here",  # Default name for reports
+            "name": f"New map ({date_time_str})",  # Default name for reports
             "display_options": data.display_options or {}
         },
     }

--- a/nextjs/src/app/(logged-in)/reports/ReportList/CreateReportCard.tsx
+++ b/nextjs/src/app/(logged-in)/reports/ReportList/CreateReportCard.tsx
@@ -9,6 +9,7 @@ import {
   CreateMapReportMutation,
   CreateMapReportMutationVariables,
 } from '@/__generated__/graphql'
+import { defaultReportConfig } from '@/app/reports/[id]/reportContext'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -42,6 +43,7 @@ export function CreateReportCard() {
           data: {
             name: new Date().toISOString(),
             organisation: { set: currentOrganisationId },
+            displayOptions: defaultReportConfig,
           },
         },
       }),

--- a/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
@@ -5,6 +5,9 @@ import React, { useEffect } from 'react'
 import { Layer, Source } from 'react-map-gl'
 import { addCountByGssToMapboxLayer } from '../../addCountByGssToMapboxLayer'
 import {
+  getAreaCountLayout,
+  getAreaGeoJSON,
+  getAreaLabelLayout,
   getChoroplethEdge,
   getChoroplethFill,
   getChoroplethFillFilter,
@@ -91,6 +94,39 @@ const PoliticalChoropleths: React.FC<PoliticalChoroplethsProps> = ({
           paint={getSelectedChoroplethEdge()}
           filter={['==', ['get', tileset.promoteId], selectedBoundary]}
           layout={{ visibility, 'line-join': 'round', 'line-round-limit': 0.1 }}
+        />
+      </Source>
+      <Source
+        id={`${tileset.mapboxSourceId}-area-count`}
+        type="geojson"
+        data={getAreaGeoJSON(countsByBoundaryType)}
+      >
+        <Layer
+          id={`${tileset.mapboxSourceId}-area-count`}
+          type="symbol"
+          layout={{
+            ...getAreaCountLayout(countsByBoundaryType),
+            visibility,
+          }}
+          paint={{
+            'text-color': 'white',
+            'text-halo-color': 'black',
+            'text-halo-width': 0.3,
+          }}
+        />
+        <Layer
+          id={`${tileset.mapboxSourceId}-area-label`}
+          type="symbol"
+          layout={{
+            ...getAreaLabelLayout(countsByBoundaryType),
+            visibility,
+          }}
+          paint={{
+            'text-color': 'white',
+            'text-opacity': 0.9,
+            'text-halo-color': 'black',
+            'text-halo-width': 0.3,
+          }}
         />
       </Source>
     </>

--- a/nextjs/src/app/reports/[id]/addCountByGssToMapboxLayer.ts
+++ b/nextjs/src/app/reports/[id]/addCountByGssToMapboxLayer.ts
@@ -1,3 +1,4 @@
+import { GroupedDataCount } from '@/__generated__/graphql'
 import { MAPBOX_LOAD_INTERVAL } from '@/lib/map/useLoadedMap'
 import { MapRef } from 'react-map-gl'
 
@@ -5,7 +6,7 @@ import { MapRef } from 'react-map-gl'
 // used in the UK to reference geographic areas for statistical purposes.
 // The data prop needs to contain the gss code and the count
 export function addCountByGssToMapboxLayer(
-  data: { gss?: string | null; count: number }[],
+  data: GroupedDataCount[],
   mapboxSourceId: string,
   sourceLayerId?: string,
   mapbox?: MapRef | null
@@ -14,7 +15,7 @@ export function addCountByGssToMapboxLayer(
   if (!sourceLayerId) throw new Error('sourceLayerId is required')
 
   setTimeout(() => {
-    data.map((d) => {
+    data.forEach((d) => {
       if (!d.gss) return
       try {
         mapbox?.setFeatureState(
@@ -23,9 +24,7 @@ export function addCountByGssToMapboxLayer(
             sourceLayer: sourceLayerId,
             id: d.gss,
           },
-          {
-            count: d.count,
-          }
+          d
         )
       } catch (e) {
         console.error(e)

--- a/nextjs/src/app/reports/[id]/mapboxStyles.ts
+++ b/nextjs/src/app/reports/[id]/mapboxStyles.ts
@@ -1,7 +1,11 @@
 import { GroupedDataCount } from '@/__generated__/graphql'
 import { scaleLinear, scaleSequential } from 'd3-scale'
 import { interpolateBlues } from 'd3-scale-chromatic'
-import { FillLayerSpecification, LineLayerSpecification } from 'mapbox-gl'
+import {
+  FillLayerSpecification,
+  LineLayerSpecification,
+  SymbolLayerSpecification,
+} from 'mapbox-gl'
 import { Tileset } from './types'
 
 export function getChoroplethFill(
@@ -97,4 +101,94 @@ export const getSelectedChoroplethFillFilter = (
   selectedGss: string
 ) => {
   return ['==', ['get', tileset.promoteId], selectedGss]
+}
+
+export function getAreaGeoJSON(data: GroupedDataCount[]) {
+  return {
+    type: 'FeatureCollection',
+    features: data
+      .filter((d) => d.gssArea?.point?.geometry)
+      .map((d) => ({
+        type: 'Feature',
+        geometry: d.gssArea?.point?.geometry! as GeoJSON.Point,
+        properties: {
+          count: d.count,
+          label: d.label,
+        },
+      })),
+  }
+}
+
+function getStatsForData(data: GroupedDataCount[]) {
+  let min =
+    data.reduce(
+      (min, p) => (p?.count! < min ? p?.count! : min),
+      data?.[0]?.count!
+    ) || 0
+  let max =
+    data.reduce(
+      (max, p) => (p?.count! > max ? p?.count! : max),
+      data?.[0]?.count!
+    ) || 1
+
+  // Ensure min and max are different to fix interpolation errors
+  if (min === max) {
+    if (min >= 1) {
+      min = min - 1
+    } else {
+      max = max + 1
+    }
+  }
+
+  const textScale = scaleLinear().domain([min, max]).range([1, 1.5])
+
+  return { min, max, textScale }
+}
+
+export const getAreaCountLayout = (
+  data: GroupedDataCount[]
+): SymbolLayerSpecification['layout'] => {
+  const { min, max, textScale } = getStatsForData(data)
+
+  return {
+    'symbol-spacing': 1000,
+    'text-field': ['get', 'count'],
+    'text-size': [
+      'interpolate',
+      ['linear'],
+      ['get', 'count'],
+      min,
+      textScale(min) * 17,
+      max,
+      textScale(max) * 17,
+    ],
+    'symbol-placement': 'point',
+    'text-offset': [0, -0.5],
+    'text-allow-overlap': true,
+    'text-ignore-placement': true,
+    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+  }
+}
+
+export const getAreaLabelLayout = (
+  data: GroupedDataCount[]
+): SymbolLayerSpecification['layout'] => {
+  const { min, max, textScale } = getStatsForData(data)
+
+  return {
+    'symbol-spacing': 1000,
+    'text-field': ['get', 'label'],
+    'text-size': [
+      'interpolate',
+      ['linear'],
+      ['get', 'count'],
+      min,
+      textScale(min) * 9,
+      max,
+      textScale(max) * 9,
+    ],
+    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+    'symbol-placement': 'point',
+    'text-offset': [0, 0.6],
+  }
 }

--- a/nextjs/src/app/reports/[id]/useBoundaryAnalytics.ts
+++ b/nextjs/src/app/reports/[id]/useBoundaryAnalytics.ts
@@ -1,4 +1,8 @@
-import { AnalyticalAreaType } from '@/__generated__/graphql'
+import {
+  AnalyticalAreaType,
+  GroupedDataCount,
+  MapReportConstituencyStatsQuery,
+} from '@/__generated__/graphql'
 import { useQuery } from '@apollo/client'
 import { useEffect, useState } from 'react'
 import {
@@ -23,7 +27,7 @@ const useBoundaryAnalytics = (
   let variables: any = {
     reportID: report?.id,
   }
-  let dataOutputKey
+  let dataOutputKey: keyof MapReportConstituencyStatsQuery['mapReport']
 
   // TODO: This is where we can implement arithmetic operations on data from multiple
   // sources, such as the sum of member count per political boundary from two different
@@ -37,12 +41,16 @@ const useBoundaryAnalytics = (
     dataOutputKey = 'importedDataCountByConstituency'
   } else if (boundaryType === 'admin_ward') {
     query = MAP_REPORT_WARD_STATS
+    // @ts-ignore — asserting here that importedDataCountByWard will also return GroupedDataCount[]
     dataOutputKey = 'importedDataCountByWard'
   } else throw new Error('Invalid boundary type')
 
-  const boundaryAnalytics = useQuery(query, { variables, skip: !canQuery })
+  const boundaryAnalytics = useQuery<MapReportConstituencyStatsQuery>(query, {
+    variables,
+    skip: !canQuery,
+  })
 
-  return boundaryAnalytics.data?.mapReport[dataOutputKey]
+  return boundaryAnalytics.data?.mapReport[dataOutputKey] as GroupedDataCount[]
 }
 
 export default useBoundaryAnalytics


### PR DESCRIPTION
Follows on from #147.

- Re-adds area names and labels which was in the old map
- Adds some stronger typing the to the Boundary Analytics hook return data