### PR TITLE
Correct layer order [MAP-661]

### DIFF
--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -168,7 +168,7 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
             "organisation": organisation,
             "slug": data.slug or slugify(data.name),
             "name": f"New map ({date_time_str})",  # Default name for reports
-            "display_options": data.display_options or {}
+            "display_options": data.display_options or {},
         },
     }
 

--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -166,6 +166,7 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
             "organisation": organisation,
             "slug": data.slug or slugify(data.name),
             "name": "Type your report name here",  # Default name for reports
+            "display_options": data.display_options or {}
         },
     }
 

--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -160,12 +160,14 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
     else:
         organisation = models.Organisation.get_or_create_for_user(user)
 
+    date_time_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
     params = {
         **graphql_type_to_dict(data, delete_null_keys=True),
         **{
             "organisation": organisation,
             "slug": data.slug or slugify(data.name),
-            "name": "Type your report name here",  # Default name for reports
+            "name": f"New map ({date_time_str})",  # Default name for reports
             "display_options": data.display_options or {}
         },
     }

--- a/nextjs/src/app/(logged-in)/reports/ReportList/CreateReportCard.tsx
+++ b/nextjs/src/app/(logged-in)/reports/ReportList/CreateReportCard.tsx
@@ -9,6 +9,7 @@ import {
   CreateMapReportMutation,
   CreateMapReportMutationVariables,
 } from '@/__generated__/graphql'
+import { defaultReportConfig } from '@/app/reports/[id]/reportContext'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -42,6 +43,7 @@ export function CreateReportCard() {
           data: {
             name: new Date().toISOString(),
             organisation: { set: currentOrganisationId },
+            displayOptions: defaultReportConfig,
           },
         },
       }),

--- a/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
@@ -19,6 +19,7 @@ import useBoundaryAnalytics from '../../useBoundaryAnalytics'
 import useSelectBoundary, {
   selectedBoundaryAtom,
 } from '../../useSelectBoundary'
+import { PLACEHOLDER_LAYER_ID_CHOROPLETH } from '../ReportPage'
 
 interface PoliticalChoroplethsProps {
   tileset: Tileset
@@ -78,6 +79,7 @@ const PoliticalChoropleths: React.FC<PoliticalChoroplethsProps> = ({
         />
         {/* Border of the boundary */}
         <Layer
+          beforeId={PLACEHOLDER_LAYER_ID_CHOROPLETH}
           id={`${tileset.mapboxSourceId}-line`}
           source={tileset.mapboxSourceId}
           source-layer={tileset.sourceLayerId}
@@ -87,6 +89,7 @@ const PoliticalChoropleths: React.FC<PoliticalChoroplethsProps> = ({
         />
         {/* Border of the selected boundary  */}
         <Layer
+          beforeId={PLACEHOLDER_LAYER_ID_CHOROPLETH}
           id={`${tileset.mapboxSourceId}-selected`}
           source={tileset.mapboxSourceId}
           source-layer={tileset.sourceLayerId}

--- a/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
@@ -110,8 +110,8 @@ const PoliticalChoropleths: React.FC<PoliticalChoroplethsProps> = ({
           }}
           paint={{
             'text-color': 'white',
-            'text-halo-color': 'black',
-            'text-halo-width': 0.3,
+            'text-halo-color': '#24262b',
+            'text-halo-width': 1.5,
           }}
         />
         <Layer
@@ -123,9 +123,9 @@ const PoliticalChoropleths: React.FC<PoliticalChoroplethsProps> = ({
           }}
           paint={{
             'text-color': 'white',
-            'text-opacity': 0.9,
-            'text-halo-color': 'black',
-            'text-halo-width': 0.3,
+            'text-opacity': 1,
+            'text-halo-color': '#24262b',
+            'text-halo-width': 1.5,
           }}
         />
       </Source>

--- a/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MapLayers/PoliticalChoropleths.tsx
@@ -5,6 +5,9 @@ import React, { useEffect } from 'react'
 import { Layer, Source } from 'react-map-gl'
 import { addCountByGssToMapboxLayer } from '../../addCountByGssToMapboxLayer'
 import {
+  getAreaCountLayout,
+  getAreaGeoJSON,
+  getAreaLabelLayout,
   getChoroplethEdge,
   getChoroplethFill,
   getChoroplethFillFilter,
@@ -91,6 +94,39 @@ const PoliticalChoropleths: React.FC<PoliticalChoroplethsProps> = ({
           paint={getSelectedChoroplethEdge()}
           filter={['==', ['get', tileset.promoteId], selectedBoundary]}
           layout={{ visibility, 'line-join': 'round', 'line-round-limit': 0.1 }}
+        />
+      </Source>
+      <Source
+        id={`${tileset.mapboxSourceId}-area-count`}
+        type="geojson"
+        data={getAreaGeoJSON(countsByBoundaryType)}
+      >
+        <Layer
+          id={`${tileset.mapboxSourceId}-area-count`}
+          type="symbol"
+          layout={{
+            ...getAreaCountLayout(countsByBoundaryType),
+            visibility,
+          }}
+          paint={{
+            'text-color': 'white',
+            'text-halo-color': 'black',
+            'text-halo-width': 0.3,
+          }}
+        />
+        <Layer
+          id={`${tileset.mapboxSourceId}-area-label`}
+          type="symbol"
+          layout={{
+            ...getAreaLabelLayout(countsByBoundaryType),
+            visibility,
+          }}
+          paint={{
+            'text-color': 'white',
+            'text-opacity': 0.9,
+            'text-halo-color': 'black',
+            'text-halo-width': 0.3,
+          }}
         />
       </Source>
     </>

--- a/nextjs/src/app/reports/[id]/(components)/MembersListPointMarkers.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MembersListPointMarkers.tsx
@@ -6,6 +6,7 @@ import { useAtom } from 'jotai'
 import { useEffect } from 'react'
 import { Layer, Source } from 'react-map-gl'
 import MarkerPopup from './MarkerPopup'
+import { PLACEHOLDER_LAYER_ID_MARKERS } from './ReportPage'
 
 const MIN_MEMBERS_ZOOM = 10
 
@@ -68,6 +69,7 @@ export function MembersListPointMarkers({
       >
         {index <= 1 ? (
           <Layer
+            beforeId={PLACEHOLDER_LAYER_ID_MARKERS}
             id={`${externalDataSourceId}-marker`}
             source={externalDataSourceId}
             source-layer={'generic_data'}
@@ -92,6 +94,7 @@ export function MembersListPointMarkers({
           />
         ) : (
           <Layer
+            beforeId={PLACEHOLDER_LAYER_ID_MARKERS}
             id={`${externalDataSourceId}-marker`}
             source={externalDataSourceId}
             source-layer={'generic_data'}
@@ -115,6 +118,7 @@ export function MembersListPointMarkers({
 
         {!!selectedSourceMarker?.properties?.id && (
           <Layer
+            beforeId={PLACEHOLDER_LAYER_ID_MARKERS}
             id={`${externalDataSourceId}-marker-selected`}
             source={externalDataSourceId}
             source-layer={'generic_data'}

--- a/nextjs/src/app/reports/[id]/(components)/ReportPage.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/ReportPage.tsx
@@ -1,11 +1,15 @@
 'use client'
 
 import LocalisedMap from '@/components/LocalisedMap'
+import { PlaceholderLayer } from '@/components/PlaceholderLayer'
 import { getPoliticalTilesetsByCountry } from '../politicalTilesets'
 import { ConstituenciesPanel } from './ConstituenciesPanel'
 import PoliticalChoropleths from './MapLayers/PoliticalChoropleths'
 import ReportMapMarkers from './MapLayers/ReportMapMarkers'
 import { useReport } from './ReportProvider'
+
+export const PLACEHOLDER_LAYER_ID_CHOROPLETH = 'choropleths'
+export const PLACEHOLDER_LAYER_ID_MARKERS = 'markers'
 
 export default function ReportPage() {
   const { report } = useReport()
@@ -18,6 +22,7 @@ export default function ReportPage() {
           initViewCountry="uk"
           mapKey={report.id}
         >
+          <PlaceholderLayer id={PLACEHOLDER_LAYER_ID_CHOROPLETH} />
           {getPoliticalTilesetsByCountry('uk').map(
             ({ boundaryType, tileset }) => (
               <PoliticalChoropleths
@@ -28,6 +33,7 @@ export default function ReportPage() {
               />
             )
           )}
+          <PlaceholderLayer id={PLACEHOLDER_LAYER_ID_MARKERS} />
           <ReportMapMarkers />
         </LocalisedMap>
       </div>

--- a/nextjs/src/app/reports/[id]/addCountByGssToMapboxLayer.ts
+++ b/nextjs/src/app/reports/[id]/addCountByGssToMapboxLayer.ts
@@ -1,3 +1,4 @@
+import { GroupedDataCount } from '@/__generated__/graphql'
 import { MAPBOX_LOAD_INTERVAL } from '@/lib/map/useLoadedMap'
 import { MapRef } from 'react-map-gl'
 
@@ -5,7 +6,7 @@ import { MapRef } from 'react-map-gl'
 // used in the UK to reference geographic areas for statistical purposes.
 // The data prop needs to contain the gss code and the count
 export function addCountByGssToMapboxLayer(
-  data: { gss?: string | null; count: number }[],
+  data: GroupedDataCount[],
   mapboxSourceId: string,
   sourceLayerId?: string,
   mapbox?: MapRef | null
@@ -14,7 +15,7 @@ export function addCountByGssToMapboxLayer(
   if (!sourceLayerId) throw new Error('sourceLayerId is required')
 
   setTimeout(() => {
-    data.map((d) => {
+    data.forEach((d) => {
       if (!d.gss) return
       try {
         mapbox?.setFeatureState(
@@ -23,9 +24,7 @@ export function addCountByGssToMapboxLayer(
             sourceLayer: sourceLayerId,
             id: d.gss,
           },
-          {
-            count: d.count,
-          }
+          d
         )
       } catch (e) {
         console.error(e)

--- a/nextjs/src/app/reports/[id]/mapboxStyles.ts
+++ b/nextjs/src/app/reports/[id]/mapboxStyles.ts
@@ -1,7 +1,11 @@
 import { GroupedDataCount } from '@/__generated__/graphql'
 import { scaleLinear, scaleSequential } from 'd3-scale'
 import { interpolateBlues } from 'd3-scale-chromatic'
-import { FillLayerSpecification, LineLayerSpecification } from 'mapbox-gl'
+import {
+  FillLayerSpecification,
+  LineLayerSpecification,
+  SymbolLayerSpecification,
+} from 'mapbox-gl'
 import { Tileset } from './types'
 
 export function getChoroplethFill(
@@ -97,4 +101,94 @@ export const getSelectedChoroplethFillFilter = (
   selectedGss: string
 ) => {
   return ['==', ['get', tileset.promoteId], selectedGss]
+}
+
+export function getAreaGeoJSON(data: GroupedDataCount[]) {
+  return {
+    type: 'FeatureCollection',
+    features: data
+      .filter((d) => d.gssArea?.point?.geometry)
+      .map((d) => ({
+        type: 'Feature',
+        geometry: d.gssArea?.point?.geometry! as GeoJSON.Point,
+        properties: {
+          count: d.count,
+          label: d.label,
+        },
+      })),
+  }
+}
+
+function getStatsForData(data: GroupedDataCount[]) {
+  let min =
+    data.reduce(
+      (min, p) => (p?.count! < min ? p?.count! : min),
+      data?.[0]?.count!
+    ) || 0
+  let max =
+    data.reduce(
+      (max, p) => (p?.count! > max ? p?.count! : max),
+      data?.[0]?.count!
+    ) || 1
+
+  // Ensure min and max are different to fix interpolation errors
+  if (min === max) {
+    if (min >= 1) {
+      min = min - 1
+    } else {
+      max = max + 1
+    }
+  }
+
+  const textScale = scaleLinear().domain([min, max]).range([1, 1.5])
+
+  return { min, max, textScale }
+}
+
+export const getAreaCountLayout = (
+  data: GroupedDataCount[]
+): SymbolLayerSpecification['layout'] => {
+  const { min, max, textScale } = getStatsForData(data)
+
+  return {
+    'symbol-spacing': 1000,
+    'text-field': ['get', 'count'],
+    'text-size': [
+      'interpolate',
+      ['linear'],
+      ['get', 'count'],
+      min,
+      textScale(min) * 17,
+      max,
+      textScale(max) * 17,
+    ],
+    'symbol-placement': 'point',
+    'text-offset': [0, -0.5],
+    'text-allow-overlap': true,
+    'text-ignore-placement': true,
+    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+  }
+}
+
+export const getAreaLabelLayout = (
+  data: GroupedDataCount[]
+): SymbolLayerSpecification['layout'] => {
+  const { min, max, textScale } = getStatsForData(data)
+
+  return {
+    'symbol-spacing': 1000,
+    'text-field': ['get', 'label'],
+    'text-size': [
+      'interpolate',
+      ['linear'],
+      ['get', 'count'],
+      min,
+      textScale(min) * 9,
+      max,
+      textScale(max) * 9,
+    ],
+    'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+    'symbol-placement': 'point',
+    'text-offset': [0, 0.6],
+  }
 }

--- a/nextjs/src/app/reports/[id]/mapboxStyles.ts
+++ b/nextjs/src/app/reports/[id]/mapboxStyles.ts
@@ -65,17 +65,28 @@ export function getChoroplethFill(
 export function getChoroplethEdge(): LineLayerSpecification['paint'] {
   return {
     'line-color': 'white',
-    'line-gap-width': [
+    'line-opacity': [
       'interpolate',
       ['exponential', 1],
       ['zoom'],
+      //
       8,
-      0,
+      0.3,
+      //
       12,
-      3,
+      1,
     ],
-    'line-opacity': 0.5,
-    'line-width': ['interpolate', ['exponential', 1], ['zoom'], 8, 0.1, 12, 1],
+    'line-width': [
+      'interpolate',
+      ['exponential', 1],
+      ['zoom'],
+      //
+      8,
+      0.3,
+      //
+      12,
+      2,
+    ],
   }
 }
 

--- a/nextjs/src/app/reports/[id]/useBoundaryAnalytics.ts
+++ b/nextjs/src/app/reports/[id]/useBoundaryAnalytics.ts
@@ -1,4 +1,8 @@
-import { AnalyticalAreaType } from '@/__generated__/graphql'
+import {
+  AnalyticalAreaType,
+  GroupedDataCount,
+  MapReportConstituencyStatsQuery,
+} from '@/__generated__/graphql'
 import { useQuery } from '@apollo/client'
 import { useEffect, useState } from 'react'
 import {
@@ -23,7 +27,7 @@ const useBoundaryAnalytics = (
   let variables: any = {
     reportID: report?.id,
   }
-  let dataOutputKey
+  let dataOutputKey: keyof MapReportConstituencyStatsQuery['mapReport']
 
   // TODO: This is where we can implement arithmetic operations on data from multiple
   // sources, such as the sum of member count per political boundary from two different
@@ -37,12 +41,16 @@ const useBoundaryAnalytics = (
     dataOutputKey = 'importedDataCountByConstituency'
   } else if (boundaryType === 'admin_ward') {
     query = MAP_REPORT_WARD_STATS
+    // @ts-ignore — asserting here that importedDataCountByWard will also return GroupedDataCount[]
     dataOutputKey = 'importedDataCountByWard'
   } else throw new Error('Invalid boundary type')
 
-  const boundaryAnalytics = useQuery(query, { variables, skip: !canQuery })
+  const boundaryAnalytics = useQuery<MapReportConstituencyStatsQuery>(query, {
+    variables,
+    skip: !canQuery,
+  })
 
-  return boundaryAnalytics.data?.mapReport[dataOutputKey]
+  return boundaryAnalytics.data?.mapReport[dataOutputKey] as GroupedDataCount[]
 }
 
 export default useBoundaryAnalytics

--- a/nextjs/src/components/LocalisedMap.tsx
+++ b/nextjs/src/components/LocalisedMap.tsx
@@ -35,7 +35,7 @@ const LocalisedMap: React.FC<LocalisedMapProps> = ({
       mapStyle={
         showStreetDetails
           ? 'mapbox://styles/commonknowledge/clubx087l014y01mj1bv63yg8'
-          : 'mapbox://styles/commonknowledge/cm4cjnvff01mx01sdcmpbfuz5/draft'
+          : `mapbox://styles/commonknowledge/cm4cjnvff01mx01sdcmpbfuz5${process.env.NODE_ENV !== 'production' ? '/draft' : ''}`
       }
       transformRequest={mapboxTransformRequest}
     >


### PR DESCRIPTION
Inherits from #149 

- Re-adds the placeholder regime so that markers reliably appear on top of choropleths and their boundary lines

# After
<img width="244" alt="Screenshot 2024-12-09 at 16 00 04" src="https://github.com/user-attachments/assets/640b6c57-4fab-4814-af48-e03a09184457">

# Before
<img width="287" alt="Screenshot 2024-12-09 at 16 00 48" src="https://github.com/user-attachments/assets/92173086-749e-4da7-bfc5-306940ca3e29">
