### PR TITLE
Improving data onboarding flow across Action Network, Google Sheets and Airtable [MAP-670] [MAP-671]

### DIFF
--- a/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -468,8 +468,6 @@ export default function Page({
   }, [testSourceResult.data])
 
   const airtableUrl = form.watch('temp.airtableBaseUrl')
-  const baseId = form.watch('airtable.baseId')
-  const tableId = form.watch('airtable.tableId')
 
   useEffect(() => {
     if (airtableUrl) {

--- a/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -473,8 +473,12 @@ export default function Page({
     if (airtableUrl) {
       try {
         const { baseId, tableId } = extractBaseAndTableId(airtableUrl)
-        if (baseId) form.setValue('airtable.baseId', baseId)
-        if (tableId) form.setValue('airtable.tableId', tableId)
+        if (baseId) {
+          form.setValue('airtable.baseId', baseId)
+        }
+        if (tableId) {
+          form.setValue('airtable.tableId', tableId)
+        }
       } catch (e) {
         // Invalid URL
         form.setError('temp.airtableBaseUrl', {

--- a/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -257,7 +257,7 @@ export default function Page({
     }
   }
 
-  function extractGroupSlug(url: string): string | null {
+  function extractActionNetworkGroupSlug(url: string): string | null {
     try {
       const match = url.match(/\/groups\/([a-zA-Z0-9-]+)\//)
       return match ? match[1] : null
@@ -1056,7 +1056,9 @@ export default function Page({
                       placeholder="https://actionnetwork.org/groups/testgroup-3/manage"
                       {...field}
                       onBlur={(e) => {
-                        const slug = extractGroupSlug(e.target.value)
+                        const slug = extractActionNetworkGroupSlug(
+                          e.target.value
+                        )
                         if (slug) {
                           form.setValue('actionnetwork.groupSlug', slug)
                         } else {

--- a/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -110,6 +110,7 @@ type FormInputs = CreateExternalDataSourceInput &
   ExternalDataSourceInput & {
     temp?: {
       airtableBaseUrl?: string
+      actionnetworkGroupUrl?: string
     }
   }
 
@@ -253,6 +254,16 @@ export default function Page({
     } catch (error) {
       console.error('Error extracting Base ID and Table ID:', error)
       return {}
+    }
+  }
+
+  function extractGroupSlug(url: string): string | null {
+    try {
+      const match = url.match(/\/groups\/([a-zA-Z0-9-]+)\//)
+      return match ? match[1] : null
+    } catch (error) {
+      console.error('Error extracting group slug:', error)
+      return null
     }
   }
 
@@ -1034,21 +1045,30 @@ export default function Page({
             <div className="text-hSm">Connection details</div>
             <FormField
               control={form.control}
-              name="actionnetwork.groupSlug"
+              name="temp.actionnetworkGroupUrl"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Action Network Group Slug</FormLabel>
+                  <FormLabel>Action Network Group URL</FormLabel>
                   <FormControl>
-                    {/* @ts-ignore */}
-                    <Input placeholder="my-group" {...field} required />
+                    <Input
+                      placeholder="https://actionnetwork.org/groups/testgroup-3/manage"
+                      {...field}
+                      onBlur={(e) => {
+                        const slug = extractGroupSlug(e.target.value)
+                        if (slug) {
+                          form.setValue('actionnetwork.groupSlug', slug)
+                        } else {
+                          form.setError('temp.actionnetworkGroupUrl', {
+                            type: 'validate',
+                            message: 'Invalid URL',
+                          })
+                        }
+                      }}
+                      required
+                    />
                   </FormControl>
                   <FormDescription>
-                    {`
-                    Get your group slug from the group dashboard in Action
-                    Network. The URL will be
-                    https://actionnetwork.org/groups/"your-group-name"/manage, 
-                    with your group slug in the place of "your-group_name".
-                    `}
+                    Paste the URL of your Action Network group here.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -1075,7 +1095,6 @@ export default function Page({
                   <FormItem>
                     <FormLabel>Action Network API key</FormLabel>
                     <FormControl>
-                      {/* @ts-ignore */}
                       <Input placeholder="52b...bce" {...field} required />
                     </FormControl>
                     <FormMessage />

--- a/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -1356,7 +1356,7 @@ export default function Page({
                   </FormControl>
                   <FormDescription>
                     Your API key can be found or generated in the Box Office
-                    Settings under API.
+                    Settings under API.{' '}
                     <a
                       className="underline"
                       target="_blank"

--- a/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
+++ b/nextjs/src/app/(logged-in)/data-sources/create/connect/[externalDataSourceType]/page.tsx
@@ -237,6 +237,7 @@ export default function Page({
   const [sheetNames, setSheetNames] = useState<string[]>([])
   const [loadingSheets, setLoadingSheets] = useState(false)
   const [fetchError, setFetchError] = useState<string | null>(null)
+  const [sheetUrl, setSheetUrl] = useState<string>('')
 
   const [createSource, createSourceResult] =
     useMutation<CreateSourceMutation>(CREATE_DATA_SOURCE)
@@ -1247,10 +1248,10 @@ export default function Page({
                   <FormControl>
                     <Input
                       placeholder="https://docs.google.com/spreadsheets/d/1MEDFli9uakvmf_wGghJZtZg2AvF2xybGtiaG7OX1mmg/edit#gid=0"
-                      value={field.value}
+                      value={sheetUrl}
                       onChange={async (e) => {
                         const url = e.target.value
-                        field.onChange(url) // Update the form value
+                        setSheetUrl(url)
                         try {
                           const match = url.match(/\/d\/([a-zA-Z0-9-_]+)/)
                           if (match && match[1]) {
@@ -1260,8 +1261,6 @@ export default function Page({
                               spreadsheetId
                             )
                             setLoadingSheets(true)
-
-                            // Fetch sheet names using OAuth credentials
                             const oauthCredentials = form.getValues(
                               'editablegooglesheets.oauthCredentials'
                             )
@@ -1289,16 +1288,12 @@ export default function Page({
                     />
                   </FormControl>
                   <FormDescription>
-                    Paste the URL of your Google Sheets document. The system
-                    will extract the spreadsheet ID and fetch sheet names
-                    automatically.
+                    Paste the URL of your Google Sheets document
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
             />
-
-            {/* Dropdown for Sheet Names */}
             <FormField
               control={form.control}
               name="editablegooglesheets.sheetName"
@@ -1308,7 +1303,6 @@ export default function Page({
                   <FormControl>
                     <Select
                       onValueChange={field.onChange}
-                      /* @ts-ignore */
                       defaultValue={field.value}
                       required
                       disabled={loadingSheets || !sheetNames.length}


### PR DESCRIPTION
## Description
This PR adds the following:
1. Airtable Base and Table IDs are extracted from the url for the Airtable base
2. Action Network group slug is extracted from the url for the Action Network group
3. Google Sheets id is extracted from  the Google Sheets URL
4. Google Sheets connected fetches the sheet names and puts them in a dropdown

## Motivation and Context
Addresses issues [MAP-671](https://linear.app/commonknowledge/issue/MAP-671/auto-extract-sheet-id-and-sheet-name-for-google-sheet) and [MAP-670](https://linear.app/commonknowledge/issue/MAP-670/auto-extract-group-slug-from-action-network-url)

## How Can It Be Tested?
Run the branch locally
Go through the add data source flows for Airtable, Action Network and Google Sheets
To authenticate a Google Sheet you'll need to run the frontend server with `npm run https`

