### PR TITLE
Make left sidebar toggle on map page

### DIFF
--- a/nextjs/src/app/reports/[id]/(components)/ReportNavbar.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/ReportNavbar.tsx
@@ -1,7 +1,10 @@
 import ReportActions from '@/app/reports/[id]/(components)/ReportActions'
 import { useReport } from '@/app/reports/[id]/(components)/ReportProvider'
+import { useSidebar } from '@/components/ui/sidebar'
+
 import { contentEditableMutation } from '@/lib/html'
 import { atom, useAtomValue } from 'jotai'
+import { PanelRight } from 'lucide-react'
 import Link from 'next/link'
 import { MappedIcon } from '../../../../components/icons/MappedIcon'
 
@@ -12,6 +15,7 @@ export const NAVBAR_HEIGHT = 48
 export default function ReportNavbar() {
   const title = useAtomValue(navbarTitleAtom)
   const { updateReport } = useReport()
+  const { toggleSidebar } = useSidebar()
 
   return (
     <nav
@@ -29,9 +33,15 @@ export default function ReportNavbar() {
         >
           {title}
         </div>
-        <ReportActions />
+        <div className="flex gap-8 items-center">
+          <ReportActions />
+          <PanelRight
+            onClick={toggleSidebar}
+            className="text-meepGray-400 w-4 h-4 cursor-pointer"
+          />{' '}
+        </div>
       </section>
-      <section className="flex space-x-4"></section>
+      <section className="flex space-x-4"> </section>
     </nav>
   )
 }


### PR DESCRIPTION

## Description
This PR adds a button to toggle the left sidebar on the map page

## Motivation and Context
Addresses issue [MAP-675](https://linear.app/commonknowledge/issue/MAP-675/make-the-sidebar-collapsible)
[Figma](https://www.figma.com/design/Z8P0RWUpZdeoFvkTrKIGjm/Mapped%3A-Hope-Not-Hate?node-id=4334-67083&t=AzPc2iaTtQWtvfZ0-0)

## How Can It Be Tested?
Download the branch and run locally
Create a map or navigate to an existing map page
Click on the sidebar panel icon in the top navbar
Observe the sidebar collapses in and out of view

## How Will This Be Deployed?
Normal deployment process

