### PR TITLE
Only show choropleth property picker when fields are present

### DIFF
--- a/nextjs/src/app/reports/[id]/(components)/ReportVisualisation.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/ReportVisualisation.tsx
@@ -136,13 +136,19 @@ const ReportVisualisation: React.FC<UpdateConfigProps> = ({
               >
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent>
-                {fieldNames?.map((field) => (
-                  <SelectItem className="font-medium" key={field} value={field}>
-                    {field}
-                  </SelectItem>
-                ))}
-              </SelectContent>
+              {fieldNames && (
+                <SelectContent>
+                  {fieldNames.map((field) => (
+                    <SelectItem
+                      className="font-medium"
+                      key={field}
+                      value={field}
+                    >
+                      {field}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              )}
             </Select>
             <p className="text-meepGray-400 text-sm font-normal mb-3 mt-3">
               Select the field from your data source


### PR DESCRIPTION

## Description
This PR adds a check so that we don't show the choropleth property picker when the relevant fields are not present

## Motivation and Context
Fixes issue [MAP-718](https://linear.app/commonknowledge/issue/MAP-718/choropleth-property-cant-be-picked)

