### PR TITLE
Adjust zoom level for map and replace circle images with mapbox circles

### DIFF
--- a/nextjs/src/app/reports/[id]/(components)/MembersListPointMarkers.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MembersListPointMarkers.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { BACKEND_URL } from '@/env'
-import { layerColour, selectedSourceMarkerAtom, useLoadedMap } from '@/lib/map'
+import { selectedSourceMarkerAtom, useLoadedMap } from '@/lib/map'
 import { useAtom } from 'jotai'
 import { MapMouseEvent } from 'mapbox-gl'
 import { useEffect } from 'react'
@@ -80,13 +80,10 @@ export function MembersListPointMarkers({
             id={`${externalDataSourceId}-marker`}
             source={externalDataSourceId}
             source-layer={'generic_data'}
-            type="symbol"
-            layout={{
-              'icon-image': `meep-marker-${index}`,
-              'icon-allow-overlap': true,
-              'icon-ignore-placement': true,
-              'icon-size': 0.75,
-              'icon-anchor': 'bottom',
+            type="circle"
+            paint={{
+              'circle-radius': 8,
+              'circle-color': '#678DE3',
             }}
             minzoom={MIN_MEMBERS_ZOOM}
             {...(selectedSourceMarker?.properties?.id
@@ -107,8 +104,8 @@ export function MembersListPointMarkers({
             source-layer={'generic_data'}
             type="circle"
             paint={{
-              'circle-radius': 5,
-              'circle-color': layerColour(index, externalDataSourceId),
+              'circle-radius': 8,
+              'circle-color': '#678DE3',
             }}
             minzoom={MIN_MEMBERS_ZOOM}
             {...(selectedSourceMarker?.properties?.id
@@ -129,13 +126,10 @@ export function MembersListPointMarkers({
             id={`${externalDataSourceId}-marker-selected`}
             source={externalDataSourceId}
             source-layer={'generic_data'}
-            type="symbol"
-            layout={{
-              'icon-image': 'meep-marker-selected',
-              'icon-size': 0.75,
-              'icon-anchor': 'bottom',
-              'icon-allow-overlap': true,
-              'icon-ignore-placement': true,
+            type="circle"
+            paint={{
+              'circle-radius': 10,
+              'circle-color': '#678DE3',
             }}
             minzoom={MIN_MEMBERS_ZOOM}
             filter={['==', selectedSourceMarker.properties.id, ['get', 'id']]}

--- a/nextjs/src/app/reports/[id]/(components)/MembersListPointMarkers.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/MembersListPointMarkers.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react'
 import { Layer, Source } from 'react-map-gl'
 import MarkerPopup from './MarkerPopup'
 import { PLACEHOLDER_LAYER_ID_MARKERS } from './ReportPage'
-const MIN_MEMBERS_ZOOM = 10
+const MIN_MEMBERS_ZOOM = 8
 
 export function MembersListPointMarkers({
   externalDataSourceId,


### PR DESCRIPTION

## Description
This PR adjusts the zoom level for the map and replaces the circle images with mapbox circles (ensures they are anchor centrally to the coordinates)

## Motivation and Context
Addresses issues [MAP-603](https://linear.app/commonknowledge/issue/MAP-603/show-map-markers-at-an-appropriate-zoom-level) and [MAP-727](https://linear.app/commonknowledge/issue/MAP-727/position-markers-at-centre-of-coordinates-not-above-or-below)
