### PR TITLE
Fix layout shift between hub editor and published page in grid column block

### DIFF
--- a/hub/graphql/types/model_types.py
+++ b/hub/graphql/types/model_types.py
@@ -9,8 +9,6 @@ from django.http import HttpRequest
 
 import numexpr as ne
 import pandas as pd
-
-pd.core.computation.ops.MATHOPS = (*pd.core.computation.ops.MATHOPS, "where")
 import procrastinate.contrib.django.models
 import strawberry
 import strawberry_django
@@ -46,6 +44,8 @@ from utils.geo_reference import (
     area_to_postcode_io_filter,
     lih_to_postcodes_io_key_map,
 )
+
+pd.core.computation.ops.MATHOPS = (*pd.core.computation.ops.MATHOPS, "where")
 
 logger = logging.getLogger(__name__)
 

--- a/nextjs/src/components/puck/config/blocks/GridRow/index.tsx
+++ b/nextjs/src/components/puck/config/blocks/GridRow/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentConfig, DropZone } from '@measured/puck'
+import { ComponentConfig } from '@measured/puck'
 
 export type GridRowProps = {
   columns: string
@@ -19,31 +19,24 @@ export const GridRow: ComponentConfig<GridRowProps> = {
   defaultProps: {
     columns: '4-columns',
   },
-  render: ({ columns }) => {
+  render: ({ columns, puck: { renderDropZone } }) => {
+    const columnCount =
+      columns === '4-columns' ? 4 : columns === '3-columns' ? 3 : 2
+
     return (
-      <>
-        {columns === '4-columns' && (
-          <div className="grid lg:grid-cols-4 sm:grid-cols-2 grid-cols-1 gap-[25px] mb-[25px]">
-            <DropZone zone="Col-1" />
-            <DropZone zone="Col-2" />
-            <DropZone zone="Col-3" />
-            <DropZone zone="Col-4" />
-          </div>
-        )}
-        {columns === '3-columns' && (
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-3 lg:gap-4 xl:gap-5 mb-8 md:mb-16 lg:mb-20">
-            <DropZone zone="Col-1" />
-            <DropZone zone="Col-2" />
-            <DropZone zone="Col-3" />
-          </div>
-        )}
-        {columns === '2-columns' && (
-          <div className="grid sm:grid-cols-2 gap-2 md:gap-3 lg:gap-4 xl:gap-5 mb-8 md:mb-16 lg:mb-20">
-            <DropZone zone="Col-1" />
-            <DropZone zone="Col-2" />
-          </div>
-        )}
-      </>
+      <div
+        className={`grid ${
+          columnCount === 4
+            ? 'lg:grid-cols-4 sm:grid-cols-2 grid-cols-1'
+            : columnCount === 3
+              ? 'sm:grid-cols-2 lg:grid-cols-3'
+              : 'sm:grid-cols-2'
+        } gap-[25px] mb-[25px]`}
+      >
+        {Array.from({ length: columnCount }).map((_, idx) => (
+          <div key={idx}>{renderDropZone({ zone: `Col-${idx + 1}` })}</div>
+        ))}
+      </div>
     )
   },
 }


### PR DESCRIPTION

## Description
This PR fixes the discrepancy between the display of the child columns in the Grid Row block in the editor and on the published page. 
The block is now using renderDropZone and has a div wrapper around each column to preserve the layout between the editor and page.

## Motivation and Context
Addresses issue [CC-205](https://linear.app/commonknowledge/issue/CC-205/fix-grid-columns-layout-shift-between-editor-and-public-page)

## How Can It Be Tested?

1. Run locally
2. Go to [http://localhost:3000/hub/editor ](http://localhost:3000/hub/editor)
3. Add a grid row block
4. Observe that on the published page the columns are displayed in the same way as in the editor

## How Will This Be Deployed?
Normal deployment process

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

