### PR TITLE
Fix count / choropleth field selection

### DIFF
--- a/hub/graphql/types/model_types.py
+++ b/hub/graphql/types/model_types.py
@@ -1700,6 +1700,7 @@ def choropleth_data_for_source(
 
     # if length of dataframe is 0, return an empty list
     if len(df) <= 0:
+        logger.debug("No data found for this source")
         return []
 
     # Break the json column into separate columns for each key
@@ -1708,13 +1709,18 @@ def choropleth_data_for_source(
     # Remove the json column
     df = df.drop(columns=["json"])
 
-    # ...
+    # Choropleth mode
+    # TODO: maybe make this explicit via an argument?
+    # is_data_source_statistical = external_data_source.data_type == models.ExternalDataSource.DataSourceType.AREA_STATS
+    # check that field is in DF
+    field_is_set = field and field is not None and len(field)
+    is_explicit_row_count = field_is_set and field == "__COUNT__"
+    is_valid_statistical_field = (
+        field_is_set and not is_explicit_row_count and field in df.columns
+    )
+    is_valid_row_counter = is_explicit_row_count or not field_is_set
 
-    if (
-        external_data_source.data_type
-        == models.ExternalDataSource.DataSourceType.AREA_STATS
-        and field is not None
-    ):
+    if is_valid_statistical_field:
         # Convert any stringified JSON numbers to floats
         for column in df:
             if all(df[column].apply(check_numeric)):
@@ -1808,7 +1814,7 @@ def choropleth_data_for_source(
             )
             for row in df.itertuples()
         ]
-    else:
+    elif is_valid_row_counter:
         # Simple count of data points per area
 
         # Count the number of rows per GSS
@@ -1838,3 +1844,5 @@ def choropleth_data_for_source(
             )
             for row in df.itertuples()
         ]
+    else:
+        raise ValueError("Incorrect configuration for choropleth")

--- a/nextjs/src/app/reports/[id]/(components)/ReportProvider.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/ReportProvider.tsx
@@ -82,7 +82,7 @@ const ReportProvider = ({ report, children }: ReportProviderProps) => {
   }, [report.layers.map((l) => l.id)])
 
   useEffect(() => {
-    // When a data source is picked, auto-select a field
+    // When a data source is picked, ensure the field is something workable
     if (
       report.displayOptions?.dataVisualisation?.dataSource &&
       !report.displayOptions?.dataVisualisation?.dataSourceField
@@ -92,7 +92,12 @@ const ReportProvider = ({ report, children }: ReportProviderProps) => {
           l.source === report.displayOptions.dataVisualisation.dataSource &&
           !!l.sourceData.fieldDefinitions?.length
       )
-      if (layer) {
+      if (
+        layer &&
+        // I.e. it's about aggregation, not about counting
+        layer.sourceData.dataType === DataSourceType.AreaStats
+        // TODO: add config option for "count of points" to make this explicit
+      ) {
         const idField = layer.sourceData.idField
         const field = layer.sourceData.fieldDefinitions?.filter(
           (f) => f.value !== idField

--- a/nextjs/src/app/reports/[id]/(components)/ReportVisualisation.tsx
+++ b/nextjs/src/app/reports/[id]/(components)/ReportVisualisation.tsx
@@ -1,5 +1,6 @@
 import { CRMSelection } from '@/components/CRMButtonItem'
 import { Textarea } from '@/components/ui/textarea'
+import { lowerCase } from 'lodash'
 import pluralize from 'pluralize'
 import React from 'react'
 import { POLITICAL_BOUNDARIES } from '../politicalTilesets'
@@ -61,9 +62,13 @@ const ReportVisualisation: React.FC = () => {
         <EditorSelect
           label="Colour by"
           // explainer={`Which field from your data source will be visualised?`}
-          value={dataSourceField}
-          options={
-            sourceMetadata?.sourceData.fieldDefinitions
+          value={dataSourceField || '__COUNT__'}
+          options={[
+            {
+              label: `Count of ${lowerCase(pluralize(selectedDataSource?.sourceData.dataType || 'record', 2))}`,
+              value: '__COUNT__',
+            },
+            ...(sourceMetadata?.sourceData.fieldDefinitions
               ?.filter(
                 // no ID fields
                 (d) => d.value !== sourceMetadata.sourceData.idField
@@ -71,21 +76,18 @@ const ReportVisualisation: React.FC = () => {
               .map((d) => ({
                 label: d.label,
                 value: d.value,
-              })) || []
-          }
+              })) || []),
+          ]}
           onChange={(dataSourceField) =>
             updateReport((draft) => {
               draft.displayOptions.dataVisualisation.dataSourceField =
                 dataSourceField
             })
           }
-          disabled={
-            !sourceMetadata ||
-            selectedDataSource?.sourceData.dataType !== 'AREA_STATS'
-          }
+          disabled={!sourceMetadata}
           disabledMessage={
             selectedDataSource?.sourceData.dataType !== 'AREA_STATS'
-              ? `Count of records per area`
+              ? `Count of ${lowerCase(pluralize(selectedDataSource?.sourceData.dataType || 'record', 2))}`
               : undefined
           }
         />


### PR DESCRIPTION
This PR ensures that wrong field values in the choropleth API don't produce weird results, and tries to funnel the map to the right kind of field values that make sense for a given data source. This will produce fewer instances of "there's nothing on the map" or "this doesn't make sense" without manual configuration.