### PR TITLE
feat: add AREA_CODE high performance geocoding

### DIFF
--- a/hub/graphql/dataloaders.py
+++ b/hub/graphql/dataloaders.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 class BasicFieldDataLoader(dataloaders.BaseDjangoModelDataLoader):
     field: str
-    filters: dict = {}
-    select_related: list = []
+    filters: dict
+    select_related: list
 
     @classmethod
     def queryset(cls, keys: list[str]):

--- a/hub/graphql/types/model_types.py
+++ b/hub/graphql/types/model_types.py
@@ -45,10 +45,7 @@ from hub.graphql.types.geojson import MultiPolygonFeature, PointFeature
 from hub.graphql.types.postcodes import PostcodesIOResult
 from hub.graphql.utils import attr_field, dict_key_field, fn_field
 from hub.management.commands.import_mps import party_shades
-from utils.geo_reference import (
-    AnalyticalAreaType,
-    area_to_postcode_io_key,
-)
+from utils.geo_reference import AnalyticalAreaType, area_to_postcode_io_key
 from utils.postcode import get_postcode_data_for_gss
 from utils.statistics import (
     attempt_interpret_series_as_float,

--- a/hub/tests/fixtures/geocoding_cases.py
+++ b/hub/tests/fixtures/geocoding_cases.py
@@ -293,3 +293,31 @@ geocoding_cases = [
         "expected_area_gss": "E05014930",
     },
 ]
+
+
+area_code_geocoding_cases = [
+    {
+        "id": "1",
+        "ward": "E05000993",
+        "expected_area_type_code": "WD23",
+        "expected_area_gss": "E05000993",
+    },
+    {
+        "id": "2",
+        "ward": "E05015081",
+        "expected_area_type_code": "WD23",
+        "expected_area_gss": "E05015081",
+    },
+    {
+        "id": "3",
+        "ward": "E05012085",
+        "expected_area_type_code": "WD23",
+        "expected_area_gss": "E05012085",
+    },
+    {
+        "id": "4",
+        "ward": "E05007461",
+        "expected_area_type_code": "WD23",
+        "expected_area_gss": "E05007461",
+    },
+]

--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -443,34 +443,16 @@ LOGGING = {
         },
     },
     "loggers": {
-        "procrastinate": (
-            {
-                "level": "DEBUG",
-                "handlers": ["console"],
-                "class": "logging.StreamHandler",
-                "formatter": "procrastinate",
-            }
-            if ENVIRONMENT != "production"
-            else {
-                "handlers": ["truncated"],
-                "level": "DEBUG",
-            }
-        ),
-        # Silence endless waiting for job log
-        "procrastinate.worker": (
-            {
-                "level": "DEBUG",
-                "handlers": ["console"],
-                "class": "logging.StreamHandler",
-                "formatter": "procrastinate",
-            }
-            if ENVIRONMENT != "production"
-            else {
-                "handlers": ["truncated"],
-                "level": "INFO",
-                "propagate": False,
-            }
-        ),
+        "procrastinate": {
+            "handlers": ["truncated"],
+            "level": "DEBUG",
+        },
+        # Silence endless waiting for job log on prod
+        "procrastinate.worker.wait_for_job": {
+            "handlers": ["console"],
+            "level": "INFO" if ENVIRONMENT == "production" else "DEBUG",
+            "propagate": False,
+        },
         "django": {
             "handlers": ["console"],
             "level": DJANGO_LOG_LEVEL,


### PR DESCRIPTION
Part of the work required for the data pipeline V2: https://linear.app/commonknowledge/issue/MAP-973/planning-for-data-import-pipeline-v2

This adds a new Geocoder: `AREA_CODE_GEOCODER_V2`. To enable it, the geocoding config must have only one element, with the `"type"` set to `"area_code"`.

This Geocoder uses dataloaders to ensure maximum parallelisation.

## To Test
Add an AreaData source, where each row is identified to an area by code. Set up the geocoding_config to look something like:

```{
  "type": "AREA",
  "components": [
    {
      "type": "area_code",
      "field": "oa21cd",
      "value": "",
      "metadata": {
        "lih_area_type__code": "OA21"
      }
    }
  ]
}```

Then run the import on the data source.