### PR TITLE
GraphQL updates

### DIFF
--- a/hub/graphql/types/geojson.py
+++ b/hub/graphql/types/geojson.py
@@ -45,6 +45,10 @@ class PointGeometry:
     # lng, lat
     coordinates: List[float]
 
+    @classmethod
+    def from_geodjango(cls, point: Point) -> "PointGeometry":
+        return PointGeometry(coordinates=[point.x, point.y])
+
 
 @strawberry.type
 class PointFeature(Feature):
@@ -57,7 +61,7 @@ class PointFeature(Feature):
     ) -> "PointFeature":
         return PointFeature(
             id=str(id),
-            geometry=PointGeometry(coordinates=point),
+            geometry=PointGeometry.from_geodjango(point),
             properties=properties,
         )
 
@@ -69,6 +73,10 @@ class PointFeature(Feature):
 class PolygonGeometry:
     type: GeoJSONTypes.Polygon = GeoJSONTypes.Polygon
     coordinates: List[List[List[float]]]
+
+    @classmethod
+    def from_geodjango(cls, polygon: Polygon) -> "PolygonGeometry":
+        return cls(coordinates=polygon.coords)
 
 
 @strawberry.type
@@ -82,12 +90,9 @@ class PolygonFeature(Feature):
     ) -> "PolygonFeature":
         return PolygonFeature(
             id=str(id),
-            geometry=PolygonGeometry(coordinates=polygon),
+            geometry=PolygonGeometry.from_geodjango(polygon),
             properties=properties,
         )
-
-
-#
 
 
 @strawberry.type
@@ -95,8 +100,9 @@ class MultiPolygonGeometry:
     type: GeoJSONTypes.MultiPolygon = GeoJSONTypes.MultiPolygon
     coordinates: JSON
 
-    def __init__(self, coordinates: MultiPolygon):
-        self.coordinates = coordinates.json
+    @classmethod
+    def from_geodjango(cls, multipolygon: MultiPolygon) -> "MultiPolygonGeometry":
+        return cls(coordinates=multipolygon.coords)
 
 
 @strawberry.type
@@ -110,6 +116,6 @@ class MultiPolygonFeature(Feature):
     ) -> "MultiPolygonFeature":
         return MultiPolygonFeature(
             id=str(id),
-            geometry=MultiPolygonGeometry(coordinates=multipolygon.json),
+            geometry=MultiPolygonGeometry.from_geodjango(multipolygon),
             properties=properties,
         )

--- a/hub/graphql/types/geojson.py
+++ b/hub/graphql/types/geojson.py
@@ -53,7 +53,7 @@ class PointGeometry:
 @strawberry.type
 class PointFeature(Feature):
     geometry: PointGeometry
-    properties: JSON
+    properties: Optional[JSON] = strawberry.field(default_factory=dict)
 
     @classmethod
     def from_geodjango(
@@ -82,7 +82,7 @@ class PolygonGeometry:
 @strawberry.type
 class PolygonFeature(Feature):
     geometry: PolygonGeometry
-    properties: JSON
+    properties: Optional[JSON] = strawberry.field(default_factory=dict)
 
     @classmethod
     def from_geodjango(
@@ -108,7 +108,7 @@ class MultiPolygonGeometry:
 @strawberry.type
 class MultiPolygonFeature(Feature):
     geometry: MultiPolygonGeometry
-    properties: JSON
+    properties: Optional[JSON] = strawberry.field(default_factory=dict)
 
     @classmethod
     def from_geodjango(

--- a/hub/graphql/types/model_types.py
+++ b/hub/graphql/types/model_types.py
@@ -740,7 +740,6 @@ class GroupedDataCount:
     formatted_count: Optional[str] = None
     area_data: Optional[strawberry.Private[Area]] = None
     is_percentage: bool = False
-    area: Optional[Area] = None
 
     @strawberry_django.field
     async def area(self, info: Info) -> Optional[Area]:
@@ -893,7 +892,10 @@ class Analytics:
             postcode_io_key=analytical_area_type.value,
             layer_ids=layer_ids,
         )
-        return [GroupedDataCount(**datum) for datum in data]
+        return [
+            GroupedDataCount(**datum, area_data=datum.get("area", None))
+            for datum in data
+        ]
 
     @strawberry_django.field
     def imported_data_count_of_areas(
@@ -940,7 +942,7 @@ class Analytics:
         )
         if len(res) == 0:
             return None
-        return GroupedDataCount(**res[0])
+        return GroupedDataCount(**res[0], area_data=res[0].get("area", None))
 
 
 @strawberry.type

--- a/hub/graphql/utils.py
+++ b/hub/graphql/utils.py
@@ -1,12 +1,8 @@
 from typing import cast
 
-from django.forms.models import model_to_dict
-
 import strawberry
 import strawberry_django
-from asgiref.sync import sync_to_async
 from strawberry.types.info import Info
-from strawberry.types.object_type import StrawberryObjectDefinition
 
 from utils.py import transform_dict_values_recursive
 

--- a/hub/graphql/utils.py
+++ b/hub/graphql/utils.py
@@ -1,6 +1,12 @@
+from typing import cast
+
+from django.forms.models import model_to_dict
+
 import strawberry
 import strawberry_django
+from asgiref.sync import sync_to_async
 from strawberry.types.info import Info
+from strawberry.types.object_type import StrawberryObjectDefinition
 
 from utils.py import transform_dict_values_recursive
 
@@ -40,3 +46,9 @@ def graphql_type_to_dict(value, delete_null_keys=False):
         lambda x: x if (x is not strawberry.UNSET) else None,
         delete_null_keys=delete_null_keys,
     )
+
+
+async def django_model_instance_to_strawberry_type(
+    instance, graphql_type: strawberry.type
+):
+    return cast(graphql_type, instance)

--- a/hub/models.py
+++ b/hub/models.py
@@ -861,6 +861,25 @@ class GenericData(CommonData):
 
         super().save(*args, **kwargs)
 
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "postcode": self.postcode,
+            "first_name": self.first_name,
+            "last_name": self.last_name,
+            "full_name": self.full_name,
+            "email": self.email,
+            "phone": self.phone,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "public_url": self.public_url,
+            "social_url": self.social_url,
+            "address": self.address,
+            "title": self.title,
+            "description": self.description,
+            "json": self.json,
+        }
+
 
 class Area(models.Model):
     mapit_id = models.CharField(max_length=30)
@@ -2749,7 +2768,9 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         priority_enum = None
         try:
             match len(members):
-                case _ if len(members) < settings.SUPER_QUICK_IMPORT_ROW_COUNT_THRESHOLD:
+                case _ if len(
+                    members
+                ) < settings.SUPER_QUICK_IMPORT_ROW_COUNT_THRESHOLD:
                     priority_enum = ProcrastinateQueuePriority.SUPER_QUICK
                 case _ if len(
                     members

--- a/nextjs/src/__generated__/graphql.ts
+++ b/nextjs/src/__generated__/graphql.ts
@@ -1493,6 +1493,7 @@ export type GroupedData = {
 
 export type GroupedDataCount = {
   __typename?: 'GroupedDataCount';
+  area?: Maybe<Area>;
   areaData?: Maybe<Area>;
   category?: Maybe<Scalars['String']['output']>;
   columns?: Maybe<Array<Scalars['String']['output']>>;
@@ -2931,6 +2932,7 @@ export type StatisticsConfig = {
   queryId?: InputMaybe<Scalars['String']['input']>;
   returnColumns?: InputMaybe<Array<Scalars['String']['input']>>;
   sourceIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  summaryCalculations?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type StrFilterLookup = {

--- a/nextjs/src/__generated__/zodSchema.ts
+++ b/nextjs/src/__generated__/zodSchema.ts
@@ -510,7 +510,8 @@ export function StatisticsConfigSchema(): z.ZodObject<Properties<StatisticsConfi
     preGroupByCalculatedColumns: z.array(CalculatedColumnSchema()).nullish(),
     queryId: z.string().nullish(),
     returnColumns: z.array(z.string()).nullish(),
-    sourceIds: z.array(z.string()).nullish()
+    sourceIds: z.array(z.string()).nullish(),
+    summaryCalculations: z.boolean().default(true).nullish()
   })
 }
 


### PR DESCRIPTION
Some GraphQL updates that helped me use Mapped for another project.

### Choropleth statistics resolver can now return GeoJSON features

Includes aggregated data, and area data, in the properties:

```
query {
  statisticsForChoropleth(
    statsConfig:{
      sourceIds:"6d5dc030-d424-45d3-8416-af222d499c1b",
      summaryCalculations:false
      groupByArea:lsoa
    }) {
    area {
      polygon {
        type
        id
        properties {
          data
        }
        geometry {
          type
          coordinates
        }
      }
    }
  }
}
```

->

```
{
  "data": {
    "statisticsForChoropleth": [
      {
        "area": {
          "polygon": {
            "type": "Feature",
            "id": "E01002024",
            "properties": {
              "data": {
                "gss": "E01002024",
                "label": "Haringey 022D",
                "area_type": 0,
                "count": 1,
                "SiteName": "London Haringey Priory Park South",
                "LSOA": 0,
                "population": 0,
                "SiteNumber": 94,
                "Latitude": 51.584128,
                "Longitude": -0.125254
              }
            },
            "geometry": {
              "type": "MultiPolygon"
            }
          }
        }
      },
      ...
    ]
  }
}
```