### PR TITLE
fix: correct sample_point used for postgis geocoding

### DIFF
--- a/hub/data_imports/geocoding_config.py
+++ b/hub/data_imports/geocoding_config.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.contrib.gis.geos import Point
+from django.contrib.gis.geos.collections import MultiPolygon
 from django.db.models import Q
 
 from asgiref.sync import sync_to_async
@@ -534,7 +535,8 @@ async def import_area_data(
 
 
 async def get_postcode_data_for_area(area: "Area", loaders: "Loaders", steps: list):
-    sample_point = area.polygon.centroid
+    polygon: MultiPolygon = area.polygon
+    sample_point = polygon.point_on_surface or polygon.centroid
 
     # get postcodeIO result for area.coordinates
     postcode_data = None

--- a/hub/tests/test_statistics.py
+++ b/hub/tests/test_statistics.py
@@ -46,7 +46,7 @@ class TestStatistics(TestGraphQLClientCase):
         # Some of that dataset uses out of date councils,
         # which have been merged together in the geocoding
         # (see `duplicate_councils`)
-        self.geocodable_council_count = 315
+        self.geocodable_council_count = 318
         self.count_regions = models.Area.objects.filter(area_type__code="EER").count()
 
     def test_count_by_area(self):

--- a/utils/postgis_geocoder.py
+++ b/utils/postgis_geocoder.py
@@ -86,7 +86,9 @@ def _get_bulk_postcode_geo_from_coords(
             if mapit_gen:
                 area_filter += f" AND mapit_generation_high = {mapit_gen}"
 
-            gis_query = f"SELECT id FROM hub_area WHERE {area_filter} ORDER BY temp.point <-> polygon LIMIT 1"
+            gis_query = f"""
+            SELECT id FROM hub_area WHERE {area_filter} AND ST_Contains(polygon, temp.point) LIMIT 1
+            """
             join = f"LEFT JOIN hub_area AS {alias} ON {alias}.id = ({gis_query})"
             area_joins.append(join)
 


### PR DESCRIPTION
## Description
When geocoding an Area, uses `area.polygon.point_on_surface` instead of `centroid` to return a point that is definitely inside the area. Also makes sure that the `postcode_data` always uses the `Area` that was matched by code, over the geocoding results.

## Motivation and Context
https://linear.app/commonknowledge/issue/MAP-1042/fix-output-area-postgis-geocoding-issue
